### PR TITLE
fix: comply with vatsim connect schema

### DIFF
--- a/app/Http/Resources/UserCollection.php
+++ b/app/Http/Resources/UserCollection.php
@@ -66,6 +66,19 @@ class UserCollection extends JsonResource
                 ],
 
             ],
+
+            'oauth' => [
+                // We're not entirely sure what the purpose of this field is, at least
+                // not for the time being.
+                //
+                // In Handover, a client making a request to the /api/user endpoint
+                // isn't going to receive a valid response containing this field
+                // *UNLESS* the token *IS* valid. Thus, if you're seeing this, you're
+                // already on the other side of the airtight hatchway.
+                //
+                // Oh, and it's apparently meant to be a string.
+                'token_valid' => 'true',
+            ],
         ];
     }
 }


### PR DESCRIPTION
See https://vatsim.dev/api/connect-api/get-user for additional details regarding the VATSIM Connect schema.

This adds a "token_valid" field which, at least for certain projects, will cause exceptions during schema strict validation. The field doesn't serve any purpose beyond successfully validating for third-party clients interested in using Handover, as any requests made to the /api/user endpoint should be (or must be?) successfully authenticated for the response to be generated.

These assumptions are not tested.