### PR TITLE
feat(groups): add attribute, tag, and direct group management system

### DIFF
--- a/app/Console/Commands/AddGroupAdmin.php
+++ b/app/Console/Commands/AddGroupAdmin.php
@@ -1,0 +1,46 @@
+<?php
+namespace App\Console\Commands;
+
+use App\Models\Group;
+use App\User;
+use Illuminate\Console\Command;
+
+class AddGroupAdmin extends Command
+{
+    protected $signature = 'groups:add-admin {cid : VATSIM CID to add as system admin}';
+    protected $description = 'Add a user to the System Administrators group, creating it if necessary';
+
+    public function handle(): int
+    {
+        $cid = (int) $this->argument('cid');
+        $user = User::find($cid);
+
+        if (!$user) {
+            $this->error("No user found with CID {$cid}.");
+            return self::FAILURE;
+        }
+
+        $existing = Group::where('slug', 'system-administrators')->first();
+
+        if ($existing && !$existing->is_admin_group) {
+            $this->error("A group with slug 'system-administrators' already exists but is not an admin group. Resolve this manually.");
+            return self::FAILURE;
+        }
+
+        $group = $existing ?? Group::create([
+            'slug' => 'system-administrators',
+            'name' => 'System Administrators',
+            'is_admin_group' => true,
+        ]);
+
+        if ($group->members()->where('user_id', $user->id)->exists()) {
+            $this->info("{$user->first_name} {$user->last_name} (CID: {$cid}) is already a member of '{$group->name}' (UUID: {$group->id}, slug: {$group->slug}).");
+            return self::SUCCESS;
+        }
+
+        $group->members()->attach($user->id, ['created_at' => now()]);
+
+        $this->info("Added {$user->first_name} {$user->last_name} (CID: {$cid}) to '{$group->name}' (UUID: {$group->id}, slug: {$group->slug}).");
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -8,12 +8,6 @@ use Illuminate\Support\Facades\Log;
 use App\User;
 use App\Http\Controllers\VatsimOAuthController;
 use App\Http\Controllers\Controller;
-use App\Http\Controllers\RatingsController;
-use App\Http\Controllers\PRatingsController;
-use App\Http\Controllers\DivisionsController;
-use App\Http\Controllers\TestController;
-use League\OAuth2\Client\Token;
-use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Session;
 
@@ -44,7 +38,7 @@ class LoginController extends Controller
                 'required_scopes' => join(' ', config('vatsim_auth.scopes')),
             ]);
             $request->session()->put('oauthstate', $this->provider->getState());
-			return redirect()->away($authorizationUrl);
+            return redirect()->away($authorizationUrl);
         } else if ($request->input('state') !== session()->pull('oauthstate')) {
             return redirect()->to('/')->withError("Login state mismatch error. Please try again. If this persists, please contact technical department.");
         } else {
@@ -58,12 +52,11 @@ class LoginController extends Controller
             $accessToken = $this->provider->getAccessToken('authorization_code', [
                 'code' => $request->input('code')
             ]);
-            
         } catch (IdentityProviderException $e) {
             return redirect()->to('/')->withError("Authentication error: ".$e->getMessage());
-        } catch (OAuthServerException $e) {
-            Log::critical("Error in OAuthServerException: ".$e);
-            return redirect()->to('/')->withError("OAuth Authentication error: ".$e->getMessage());
+        } catch (\Exception $e) {
+            Log::error('OAuth token exchange failed: '.get_class($e).' '.$e->getMessage());
+            return redirect()->to('/')->withError("Authentication error: ".$e->getMessage());
         }
 
         $resourceOwner = json_decode(json_encode($this->provider->getResourceOwner($accessToken)->toArray()));
@@ -78,7 +71,7 @@ class LoginController extends Controller
         ) {
             return redirect()->to('/')->withError("Please grant us your full name, email address, VATSIM details, country and continious access to access our services. You will be presented with our Data Protection Policy before the data will get stored with us.");
         }
-        
+
         if ($resourceOwner->data->vatsim->rating->id == 0) {
             return redirect()->route('landing')->withError('<b>Login denied.</b><br>Login was denied because you are suspended from VATSIM.');
         }
@@ -94,15 +87,13 @@ class LoginController extends Controller
             return redirect()->route('landing')->withError('<br>Login denied</br><br>User '.$user->id.' has been banned in '.\Config::get('app.owner_short').' for the following reason: <i>'.$user->banned->reason.'</i><br><br>For inquires contact '.\Config::get('app.owner_contact').'');
         }
 
-        // Check if user exists and accepted privacy policy                
+        // Check if user exists and accepted privacy policy
         if($user && $user->accepted_privacy){
             return $this->completeLogin($resourceOwner, $accessToken);
         } else {
             session(['resourceOwner' => $resourceOwner, 'accessToken' => $accessToken]); // Store CERT data temporarily
             return redirect()->route('dpp');
         }
-
-        
     }
 
     public function validatePrivacy(Request $get){
@@ -122,7 +113,6 @@ class LoginController extends Controller
 
     protected function completeLogin($resourceOwner, $token)
     {
-
         $account = User::updateOrCreate(
             ['id' => $resourceOwner->data->cid],
             ['email' => $resourceOwner->data->personal->email,
@@ -149,7 +139,7 @@ class LoginController extends Controller
         // Complete login and redirect to intended url
         Auth::login(User::find($resourceOwner->data->cid), false);
 
-        $intended = $intended = Session::pull('url.intended', route('landing'));
+        $intended = Session::pull('url.intended', route('landing'));
         return redirect($intended);
     }
 

--- a/app/Http/Controllers/GroupAttributeDefinitionController.php
+++ b/app/Http/Controllers/GroupAttributeDefinitionController.php
@@ -1,0 +1,54 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\GroupAttributeDefinition;
+use Illuminate\Http\Request;
+
+class GroupAttributeDefinitionController extends Controller
+{
+    public function index()
+    {
+        $this->requireAdmin(request());
+        $definitions = GroupAttributeDefinition::orderBy('key')->get();
+        return view('groups.attributes', compact('definitions'));
+    }
+
+    public function store(Request $request)
+    {
+        $this->requireAdmin($request);
+        $data = $request->validate([
+            'key'   => ['required', 'regex:/^[a-z0-9_-]+$/', 'max:32', 'unique:group_attribute_definitions,key'],
+            'label' => ['required', 'string', 'max:255'],
+        ]);
+        GroupAttributeDefinition::create($data);
+        return redirect()->route('groups.attributes.index')->with('success', 'Attribute definition created.');
+    }
+
+    public function update(Request $request, GroupAttributeDefinition $definition)
+    {
+        $this->requireAdmin($request);
+        $data = $request->validate([
+            'label' => ['required', 'string', 'max:255'],
+        ]);
+        $definition->update($data);
+        return redirect()->route('groups.attributes.index')->with('success', 'Attribute definition updated.');
+    }
+
+    public function destroy(Request $request, GroupAttributeDefinition $definition)
+    {
+        $this->requireAdmin($request);
+        try {
+            $definition->delete();
+        } catch (\Illuminate\Database\QueryException) {
+            return back()->withErrors(['definition' => 'Cannot delete: referenced by existing values or rules.']);
+        }
+        return redirect()->route('groups.attributes.index')->with('success', 'Attribute definition deleted.');
+    }
+
+    private function requireAdmin(Request $request): void
+    {
+        if (!$request->attributes->get('is_group_admin')) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -1,0 +1,179 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\Services\GroupManagerService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
+
+class GroupController extends Controller
+{
+    public function __construct(private GroupManagerService $service) {}
+
+    public function index()
+    {
+        $request = request();
+        $isAdmin = $request->attributes->get('is_group_admin');
+        if ($isAdmin) {
+            $groups = Group::withCount('members')->with('tags')->orderBy('name')->paginate(25);
+        } else {
+            $ids = $request->attributes->get('manageable_group_ids', []);
+            $groups = Group::withCount('members')->with('tags')->whereIn('id', $ids)->orderBy('name')->paginate(25);
+        }
+        return view('groups.index', compact('groups', 'isAdmin'));
+    }
+
+    public function create(Request $request)
+    {
+        $this->requireAdmin($request);
+        $definitions = GroupAttributeDefinition::orderBy('key')->get();
+        return view('groups.create', compact('definitions'));
+    }
+
+    public function store(Request $request)
+    {
+        $this->requireAdmin($request);
+        $data = $this->validateGroup($request);
+
+        $group = DB::transaction(function () use ($data) {
+            $g = Group::create([
+                'slug'           => $data['slug'],
+                'name'           => $data['name'],
+                'description'    => $data['description'] ?? null,
+                'is_admin_group' => (bool) ($data['is_admin_group'] ?? false),
+            ]);
+            $this->syncTags($g, $data['tags'] ?? []);
+            $this->syncAttributeValues($g, $data['attributes'] ?? []);
+            return $g;
+        });
+
+        $this->service->incrementCacheVersion();
+
+        return redirect()->route('groups.show', $group)->with('success', 'Group created.');
+    }
+
+    public function show(Request $request, Group $group)
+    {
+        if (!$request->attributes->get('is_group_admin') && !$this->service->canManage($request->user(), $group)) {
+            abort(403);
+        }
+        $group->load('tags', 'attributeValues.definition');
+        $definitions = GroupAttributeDefinition::orderBy('key')->get();
+        $isAdmin = $request->attributes->get('is_group_admin');
+        $grantingRules = $isAdmin ? [] : $this->service->grantingRulesFor($request->user(), $group);
+        return view('groups.show', compact('group', 'definitions', 'isAdmin', 'grantingRules'));
+    }
+
+    public function edit(Request $request, Group $group)
+    {
+        $this->requireAdmin($request);
+        $group->load('tags', 'attributeValues.definition');
+        $definitions = GroupAttributeDefinition::orderBy('key')->get();
+        return view('groups.edit', compact('group', 'definitions'));
+    }
+
+    public function update(Request $request, Group $group)
+    {
+        $this->requireAdmin($request);
+        $data = $this->validateGroup($request, $group->id);
+
+        $oldIsAdmin = $group->is_admin_group;
+        $newIsAdmin = (bool) ($data['is_admin_group'] ?? false);
+
+        if ($oldIsAdmin && !$newIsAdmin) {
+            $hasOtherAdminGroup = Group::where('is_admin_group', true)->where('id', '!=', $group->id)->exists();
+            if (!$hasOtherAdminGroup) {
+                return back()->withErrors(['is_admin_group' => 'Cannot demote the only admin group.']);
+            }
+        }
+
+        DB::transaction(function () use ($data, $group, $oldIsAdmin, $newIsAdmin, $request) {
+            $group->update([
+                'slug'           => $data['slug'],
+                'name'           => $data['name'],
+                'description'    => $data['description'] ?? null,
+                'is_admin_group' => $newIsAdmin,
+            ]);
+
+            if ($oldIsAdmin !== $newIsAdmin) {
+                Log::warning('is_admin_group toggled', [
+                    'group_id'   => $group->id,
+                    'group_slug' => $group->slug,
+                    'changed_by' => $request->user()->id,
+                    'old_value'  => $oldIsAdmin,
+                    'new_value'  => $newIsAdmin,
+                ]);
+            }
+
+            $this->syncTags($group, $data['tags'] ?? []);
+            $this->syncAttributeValues($group, $data['attributes'] ?? []);
+        });
+
+        $this->service->incrementCacheVersion();
+
+        return redirect()->route('groups.show', $group)->with('success', 'Group updated.');
+    }
+
+    public function destroy(Request $request, Group $group)
+    {
+        $this->requireAdmin($request);
+        try {
+            $group->delete();
+        } catch (\Illuminate\Database\QueryException) {
+            return back()->withErrors(['group' => 'Cannot delete: group still has members.']);
+        }
+        $this->service->incrementCacheVersion();
+        return redirect()->route('groups.index')->with('success', 'Group deleted.');
+    }
+
+    private function validateGroup(Request $request, ?string $groupId = null): array
+    {
+        $reserved = ['create', 'attributes', 'me', 'search', 'admin', 'edit', 'rules'];
+        $slugRule = $groupId
+            ? Rule::unique('groups', 'slug')->ignore($groupId, 'id')
+            : Rule::unique('groups', 'slug');
+
+        return $request->validate([
+            'slug'           => ['required', 'regex:/^[a-z0-9-]+$/', 'max:64', $slugRule, Rule::notIn($reserved)],
+            'name'           => ['required', 'string', 'max:255'],
+            'description'    => ['nullable', 'string', 'max:1000'],
+            'is_admin_group' => ['nullable', 'boolean'],
+            'tags'           => ['nullable', 'array'],
+            'tags.*'         => ['string', 'regex:/^[a-z0-9-]+$/', 'max:32'],
+            'attributes'     => ['nullable', 'array'],
+            'attributes.*'   => ['nullable', 'string', 'max:255'],
+        ]);
+    }
+
+    private function syncTags(Group $group, array $tags): void
+    {
+        $group->tags()->delete();
+        foreach (array_values(array_unique(array_filter($tags))) as $tag) {
+            $group->tags()->create(['tag' => $tag]);
+        }
+    }
+
+    private function syncAttributeValues(Group $group, array $attributes): void
+    {
+        foreach ($attributes as $definitionId => $value) {
+            if ($value === null || $value === '') {
+                $group->attributeValues()->where('attribute_definition_id', $definitionId)->delete();
+            } else {
+                $group->attributeValues()->updateOrCreate(
+                    ['attribute_definition_id' => $definitionId],
+                    ['value' => $value]
+                );
+            }
+        }
+    }
+
+    private function requireAdmin(Request $request): void
+    {
+        if (!$request->attributes->get('is_group_admin')) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Controllers/GroupManagerRuleController.php
+++ b/app/Http/Controllers/GroupManagerRuleController.php
@@ -1,0 +1,166 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\Models\GroupManagerRuleByAttribute;
+use App\Models\GroupManagerRuleByGroup;
+use App\Models\GroupManagerRuleByTag;
+use App\Services\GroupManagerService;
+use Illuminate\Http\Request;
+
+class GroupManagerRuleController extends Controller
+{
+    public function __construct(private GroupManagerService $service) {}
+
+    public function destroyFromOverview(Request $request, string $type, int $rule)
+    {
+        $this->requireAdmin($request);
+
+        match ($type) {
+            'group'     => GroupManagerRuleByGroup::findOrFail($rule)->delete(),
+            'tag'       => GroupManagerRuleByTag::findOrFail($rule)->delete(),
+            'attribute' => GroupManagerRuleByAttribute::findOrFail($rule)->delete(),
+            default     => abort(404),
+        };
+
+        $this->service->incrementCacheVersion();
+        return back()->with('success', 'Rule removed.');
+    }
+
+    public function overview()
+    {
+        $request = request();
+        $this->requireAdmin($request);
+
+        $groupRules = GroupManagerRuleByGroup::with(['managerGroup', 'targetGroup'])->get();
+        $tagRules   = GroupManagerRuleByTag::with('managerGroup')->get();
+        $attrRules  = GroupManagerRuleByAttribute::with('managerGroup')->get();
+
+        $rules = collect()
+            ->merge($groupRules->map(fn($r) => ['manager' => $r->managerGroup, 'type' => 'group',     'rule' => $r]))
+            ->merge($tagRules->map(fn($r)   => ['manager' => $r->managerGroup, 'type' => 'tag',       'rule' => $r]))
+            ->merge($attrRules->map(fn($r)  => ['manager' => $r->managerGroup, 'type' => 'attribute', 'rule' => $r]))
+            ->filter(fn($e) => $e['manager'] !== null)
+            ->sortBy('manager.name')
+            ->values();
+
+        return view('groups.rules-overview', compact('rules'));
+    }
+
+    public function index()
+    {
+        $request = request();
+        $this->requireAdmin($request);
+
+        $slug = $request->route('group');
+        $group = $slug instanceof Group ? $slug : Group::where('slug', $slug)->firstOrFail();
+        $group->load('tags', 'attributeValues.definition', 'targetedByGroupRules.managerGroup');
+
+        $allGroups = Group::orderBy('name')->get();
+        $definitions = GroupAttributeDefinition::orderBy('key')->get();
+
+        $tagRules = $group->tags->isEmpty()
+            ? collect()
+            : GroupManagerRuleByTag::with('managerGroup')
+                ->whereIn('target_tag', $group->tags->pluck('tag')->toArray())
+                ->get();
+
+        $attrRules = GroupManagerRuleByAttribute::with('managerGroup')
+            ->get()
+            ->filter(fn ($r) => $group->attributeValues()
+                ->where('value', $r->target_attribute_value)
+                ->whereHas('definition', fn ($q) => $q->where('key', $r->target_attribute_key))
+                ->exists()
+            );
+
+        return view('groups.rules', compact('group', 'allGroups', 'definitions', 'tagRules', 'attrRules'));
+    }
+
+    public function store(Request $request, Group $group)
+    {
+        $this->requireAdmin($request);
+        $type = $request->validate(['type' => 'required|in:group,tag,attribute'])['type'];
+
+        match ($type) {
+            'group'     => $this->storeGroupRule($request, $group),
+            'tag'       => $this->storeTagRule($request, $group),
+            'attribute' => $this->storeAttributeRule($request, $group),
+        };
+
+        $this->service->incrementCacheVersion();
+        return back()->with('success', 'Rule added.');
+    }
+
+    public function destroy(Request $request, Group $group, string $type, int $rule)
+    {
+        $this->requireAdmin($request);
+
+        match ($type) {
+            'group' => GroupManagerRuleByGroup::where('id', $rule)
+                ->where('target_group_id', $group->id)
+                ->firstOrFail()
+                ->delete(),
+            'tag' => tap(GroupManagerRuleByTag::findOrFail($rule), function ($r) use ($group) {
+                abort_unless($group->tags()->where('tag', $r->target_tag)->exists(), 404);
+            })->delete(),
+            'attribute' => tap(GroupManagerRuleByAttribute::findOrFail($rule), function ($r) use ($group) {
+                abort_unless(
+                    $group->attributeValues()
+                        ->whereHas('definition', fn ($q) => $q->where('key', $r->target_attribute_key))
+                        ->where('value', $r->target_attribute_value)
+                        ->exists(),
+                    404
+                );
+            })->delete(),
+            default => abort(404),
+        };
+
+        $this->service->incrementCacheVersion();
+        return back()->with('success', 'Rule removed.');
+    }
+
+    private function storeGroupRule(Request $request, Group $group): void
+    {
+        $data = $request->validate([
+            'manager_group_id' => ['required', 'uuid', 'exists:groups,id'],
+        ]);
+        GroupManagerRuleByGroup::firstOrCreate([
+            'manager_group_id' => $data['manager_group_id'],
+            'target_group_id'  => $group->id,
+        ]);
+    }
+
+    private function storeTagRule(Request $request, Group $group): void
+    {
+        $data = $request->validate([
+            'manager_group_id' => ['required', 'uuid', 'exists:groups,id'],
+            'target_tag'       => ['required', 'regex:/^[a-z0-9-]+$/', 'max:32'],
+        ]);
+        GroupManagerRuleByTag::firstOrCreate([
+            'manager_group_id' => $data['manager_group_id'],
+            'target_tag'       => $data['target_tag'],
+        ]);
+    }
+
+    private function storeAttributeRule(Request $request, Group $group): void
+    {
+        $data = $request->validate([
+            'manager_group_id'       => ['required', 'uuid', 'exists:groups,id'],
+            'target_attribute_key'   => ['required', 'exists:group_attribute_definitions,key'],
+            'target_attribute_value' => ['required', 'string', 'max:255'],
+        ]);
+        GroupManagerRuleByAttribute::firstOrCreate([
+            'manager_group_id'       => $data['manager_group_id'],
+            'target_attribute_key'   => $data['target_attribute_key'],
+            'target_attribute_value' => $data['target_attribute_value'],
+        ]);
+    }
+
+    private function requireAdmin(Request $request): void
+    {
+        if (!$request->attributes->get('is_group_admin')) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Controllers/GroupMemberController.php
+++ b/app/Http/Controllers/GroupMemberController.php
@@ -1,0 +1,83 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Group;
+use App\Services\GroupManagerService;
+use App\User;
+use Illuminate\Http\Request;
+
+class GroupMemberController extends Controller
+{
+    public function __construct(private GroupManagerService $service) {}
+
+    public function index()
+    {
+        $request = request();
+        $slug = $request->route('group');
+        $group = $slug instanceof \App\Models\Group ? $slug : \App\Models\Group::where('slug', $slug)->firstOrFail();
+
+        $this->requireAccess($request, $group);
+
+        $search = $request->get('search');
+        $query = $group->members()->orderBy('first_name');
+
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->where('first_name', 'like', $search . '%')
+                  ->orWhere('last_name', 'like', $search . '%')
+                  ->orWhere('users.id', $search);
+            });
+        }
+
+        $members = $query->paginate(25)->withQueryString();
+        return view('groups.members', compact('group', 'members', 'search'));
+    }
+
+    public function store(Request $request, Group $group)
+    {
+        $this->requireAccess($request, $group);
+        $request->validate(['cid' => ['required', 'integer']]);
+
+        $user = User::find($request->cid);
+        if (!$user) {
+            abort(404, "No user found with CID {$request->cid}.");
+        }
+
+        if ($group->members()->where('user_id', $user->id)->exists()) {
+            return back()->with('info', "{$user->first_name} {$user->last_name} is already a member — no action taken.");
+        }
+
+        $group->members()->attach($user->id, [
+            'added_by'   => $request->user()->id,
+            'created_at' => now(),
+        ]);
+        $this->service->incrementCacheVersion();
+
+        return back()->with('success', "{$user->first_name} {$user->last_name} added.");
+    }
+
+    public function destroy(Request $request, Group $group, User $user)
+    {
+        $this->requireAccess($request, $group);
+
+        if (!$group->members()->where('user_id', $user->id)->exists()) {
+            return back()->with('info', "{$user->first_name} {$user->last_name} is not a member — no action taken.");
+        }
+
+        if ($group->is_admin_group && $group->members()->count() === 1) {
+            return back()->withErrors(['member' => 'Cannot remove the last member of an admin group.']);
+        }
+
+        $group->members()->detach($user->id);
+        $this->service->incrementCacheVersion();
+
+        return back()->with('success', "{$user->first_name} {$user->last_name} removed.");
+    }
+
+    private function requireAccess(Request $request, Group $group): void
+    {
+        if (!$request->attributes->get('is_group_admin') && !$this->service->canManage($request->user(), $group)) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,6 +62,7 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'suspended' => \App\Http\Middleware\SuspendedUser::class,
+        'groups.manage' => \App\Http\Middleware\ManagesGroups::class,
     ];
 
     /**

--- a/app/Http/Middleware/ManagesGroups.php
+++ b/app/Http/Middleware/ManagesGroups.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Http\Middleware;
+
+use App\Services\GroupManagerService;
+use Closure;
+use Illuminate\Http\Request;
+
+class ManagesGroups
+{
+    public function __construct(private GroupManagerService $service) {}
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $user = $request->user();
+        $isAdmin = $this->service->isAdmin($user);
+        $manageableIds = $this->service->manageableGroupIds($user);
+
+        if (!$isAdmin && empty($manageableIds)) {
+            abort(403, 'You do not have access to group management.');
+        }
+
+        $request->attributes->set('is_group_admin', $isAdmin);
+        $request->attributes->set('manageable_group_ids', $manageableIds);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Resources/GroupResource.php
+++ b/app/Http/Resources/GroupResource.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class GroupResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id'         => $this->id,
+            'slug'       => $this->slug,
+            'name'       => $this->name,
+            'tags'       => $this->tags->pluck('tag')->values()->toArray(),
+            'attributes' => $this->attributeValues
+                ->mapWithKeys(fn ($av) => [$av->definition->key => $av->value])
+                ->toArray(),
+        ];
+    }
+}

--- a/app/Http/Resources/UserCollection.php
+++ b/app/Http/Resources/UserCollection.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Http\Resources\GroupResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class UserCollection extends JsonResource
@@ -79,6 +80,13 @@ class UserCollection extends JsonResource
                 // Oh, and it's apparently meant to be a string.
                 'token_valid' => 'true',
             ],
+
+            'groups' => $this->when(
+                $this->tokenCan('groups'),
+                fn () => GroupResource::collection(
+                    $this->groups()->with('tags', 'attributeValues.definition')->get()
+                )
+            ),
         ];
     }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -1,0 +1,60 @@
+<?php
+namespace App\Models;
+
+use App\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Group extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $fillable = ['slug', 'name', 'description', 'is_admin_group'];
+    protected $casts = ['is_admin_group' => 'boolean'];
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function tags(): HasMany
+    {
+        return $this->hasMany(GroupTag::class);
+    }
+
+    public function attributeValues(): HasMany
+    {
+        return $this->hasMany(GroupAttributeValue::class);
+    }
+
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'group_user')
+            ->withPivot('added_by', 'created_at');
+    }
+
+    // Rules FROM this group (what it manages)
+    public function managerRulesByGroup(): HasMany
+    {
+        return $this->hasMany(GroupManagerRuleByGroup::class, 'manager_group_id');
+    }
+
+    public function managerRulesByTag(): HasMany
+    {
+        return $this->hasMany(GroupManagerRuleByTag::class, 'manager_group_id');
+    }
+
+    public function managerRulesByAttribute(): HasMany
+    {
+        return $this->hasMany(GroupManagerRuleByAttribute::class, 'manager_group_id');
+    }
+
+    // Rules TO this group (who can manage it) — used on the rules management page
+    public function targetedByGroupRules(): HasMany
+    {
+        return $this->hasMany(GroupManagerRuleByGroup::class, 'target_group_id');
+    }
+}

--- a/app/Models/GroupAttributeDefinition.php
+++ b/app/Models/GroupAttributeDefinition.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class GroupAttributeDefinition extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['key', 'label'];
+
+    public function values(): HasMany
+    {
+        return $this->hasMany(GroupAttributeValue::class, 'attribute_definition_id');
+    }
+}

--- a/app/Models/GroupAttributeValue.php
+++ b/app/Models/GroupAttributeValue.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupAttributeValue extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['group_id', 'attribute_definition_id', 'value'];
+
+    public function definition(): BelongsTo
+    {
+        return $this->belongsTo(GroupAttributeDefinition::class, 'attribute_definition_id');
+    }
+}

--- a/app/Models/GroupManagerRuleByAttribute.php
+++ b/app/Models/GroupManagerRuleByAttribute.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupManagerRuleByAttribute extends Model
+{
+    protected $table = 'group_manager_rules_by_attribute';
+    protected $fillable = ['manager_group_id', 'target_attribute_key', 'target_attribute_value'];
+
+    public function managerGroup(): BelongsTo
+    {
+        return $this->belongsTo(Group::class, 'manager_group_id');
+    }
+}

--- a/app/Models/GroupManagerRuleByGroup.php
+++ b/app/Models/GroupManagerRuleByGroup.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupManagerRuleByGroup extends Model
+{
+    protected $table = 'group_manager_rules_by_group';
+    protected $fillable = ['manager_group_id', 'target_group_id'];
+
+    public function managerGroup(): BelongsTo
+    {
+        return $this->belongsTo(Group::class, 'manager_group_id');
+    }
+
+    public function targetGroup(): BelongsTo
+    {
+        return $this->belongsTo(Group::class, 'target_group_id');
+    }
+}

--- a/app/Models/GroupManagerRuleByTag.php
+++ b/app/Models/GroupManagerRuleByTag.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupManagerRuleByTag extends Model
+{
+    protected $table = 'group_manager_rules_by_tag';
+    protected $fillable = ['manager_group_id', 'target_tag'];
+
+    public function managerGroup(): BelongsTo
+    {
+        return $this->belongsTo(Group::class, 'manager_group_id');
+    }
+}

--- a/app/Models/GroupTag.php
+++ b/app/Models/GroupTag.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GroupTag extends Model
+{
+    public $timestamps = false;
+    protected $fillable = ['group_id', 'tag'];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+}

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Group;
+use App\Services\GroupManagerService;
+use App\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class GroupPolicy
+{
+    use HandlesAuthorization;
+
+    public function __construct(private GroupManagerService $service) {}
+
+    /**
+     * Whether the user may access group management at all — i.e. they are a
+     * system admin, or at least one group is manageable to them via a rule.
+     * Mirrors the App\Http\Middleware\ManagesGroups guard.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $this->service->isAdmin($user) || ! empty($this->service->manageableGroupIds($user));
+    }
+
+    /**
+     * Whether the user may manage a specific group (view its detail page,
+     * its members and rules). Admins may manage every group.
+     */
+    public function manage(User $user, Group $group): bool
+    {
+        return $this->service->canManage($user, $group);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,9 +3,10 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Gate;
 use Laravel\Passport\Passport;
 use App\Models\Passport\Client;
+use App\Models\Group;
+use App\Policies\GroupPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -15,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        'App\Model' => 'App\Policies\ModelPolicy',
+        Group::class => GroupPolicy::class,
     ];
 
     /**
@@ -29,10 +30,11 @@ class AuthServiceProvider extends ServiceProvider
         // Don't be fooled, we return ALL data from OAuthUserController.php without checking for requested tokens.
         // We only initiate tokens here so we can use Handover as if it were Vatsim Connect and tokens are passed.
         Passport::tokensCan([
-            'full_name' => 'First and last name',
-            'email' => 'E-mail address',
+            'full_name'      => 'First and last name',
+            'email'          => 'E-mail address',
             'vatsim_details' => 'Ratings and divisions',
-            'country' => 'Country'
+            'country'        => 'Country',
+            'groups'         => 'View the groups you are a member of',
         ]);
 
         Passport::setDefaultScope([

--- a/app/Services/GroupManagerService.php
+++ b/app/Services/GroupManagerService.php
@@ -1,0 +1,119 @@
+<?php
+namespace App\Services;
+
+use App\Models\Group;
+use App\Models\GroupManagerRuleByAttribute;
+use App\Models\GroupManagerRuleByGroup;
+use App\Models\GroupManagerRuleByTag;
+use App\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class GroupManagerService
+{
+    public function isAdmin(User $user): bool
+    {
+        return $user->groups()->where('is_admin_group', true)->exists();
+    }
+
+    public function canManage(User $user, Group $group): bool
+    {
+        if ($this->isAdmin($user)) {
+            return true;
+        }
+        return in_array($group->id, $this->manageableGroupIds($user), strict: true);
+    }
+
+    public function manageableGroupIds(User $user): array
+    {
+        $version = Cache::get('groups:cache_version', 0);
+        return Cache::remember(
+            "user:{$user->id}:manageable_groups:v{$version}",
+            300,
+            fn () => $this->resolveManageableGroupIds($user)
+        );
+    }
+
+    public function incrementCacheVersion(): void
+    {
+        Cache::increment('groups:cache_version');
+    }
+
+    public function grantingRulesFor(User $user, Group $group): array
+    {
+        $userGroupIds = $user->groups()->pluck('groups.id')->toArray();
+        if (empty($userGroupIds)) {
+            return [];
+        }
+
+        $rules = [];
+
+        GroupManagerRuleByGroup::whereIn('manager_group_id', $userGroupIds)
+            ->where('target_group_id', $group->id)
+            ->with('managerGroup')
+            ->get()
+            ->each(fn ($r) => $rules[] = "Member of \"{$r->managerGroup->name}\"");
+
+        $groupTags = $group->tags->pluck('tag')->toArray();
+        if (!empty($groupTags)) {
+            GroupManagerRuleByTag::whereIn('manager_group_id', $userGroupIds)
+                ->whereIn('target_tag', $groupTags)
+                ->with('managerGroup')
+                ->get()
+                ->each(fn ($r) => $rules[] = "Member of \"{$r->managerGroup->name}\" (via tag \"{$r->target_tag}\")");
+        }
+
+        $group->loadMissing('attributeValues.definition');
+        $groupAttrPairs = $group->attributeValues->mapWithKeys(fn ($av) => [
+            $av->definition->key => $av->value
+        ])->all();
+
+        GroupManagerRuleByAttribute::whereIn('manager_group_id', $userGroupIds)
+            ->with('managerGroup')
+            ->get()
+            ->each(function ($r) use ($groupAttrPairs, &$rules) {
+                if (($groupAttrPairs[$r->target_attribute_key] ?? null) === $r->target_attribute_value) {
+                    $rules[] = "Member of \"{$r->managerGroup->name}\" (via {$r->target_attribute_key}={$r->target_attribute_value})";
+                }
+            });
+
+        return $rules;
+    }
+
+    private function resolveManageableGroupIds(User $user): array
+    {
+        $userGroupIds = $user->groups()->pluck('groups.id')->toArray();
+        if (empty($userGroupIds)) {
+            return [];
+        }
+
+        $byGroup = GroupManagerRuleByGroup::whereIn('manager_group_id', $userGroupIds)
+            ->pluck('target_group_id')
+            ->toArray();
+
+        $tags = GroupManagerRuleByTag::whereIn('manager_group_id', $userGroupIds)
+            ->pluck('target_tag')
+            ->toArray();
+        $byTag = empty($tags) ? [] : Group::whereHas('tags', fn ($q) => $q->whereIn('tag', $tags))
+            ->pluck('id')
+            ->toArray();
+
+        $attrRules = GroupManagerRuleByAttribute::whereIn('manager_group_id', $userGroupIds)->get();
+        $byAttribute = [];
+        if ($attrRules->isNotEmpty()) {
+            $byAttribute = DB::table('group_attribute_values')
+                ->join('group_attribute_definitions', 'group_attribute_definitions.id', '=', 'group_attribute_values.attribute_definition_id')
+                ->where(function ($q) use ($attrRules) {
+                    foreach ($attrRules as $rule) {
+                        $q->orWhere(fn ($w) => $w
+                            ->where('group_attribute_definitions.key', $rule->target_attribute_key)
+                            ->where('group_attribute_values.value', $rule->target_attribute_value));
+                    }
+                })
+                ->pluck('group_attribute_values.group_id')
+                ->toArray();
+        }
+
+        return array_values(array_unique(array_merge($byGroup, $byTag, $byAttribute)));
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -3,6 +3,9 @@
 namespace App;
 
 use App\Http\Controllers\VatsimOAuthController;
+use App\Models\Group;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use League\OAuth2\Client\Token\AccessToken;
 use Laravel\Passport\HasApiTokens;
@@ -11,9 +14,10 @@ use Laravel\Passport\HasApiTokens;
 class User extends Authenticatable
 {
 
-    use HasApiTokens;
+    use HasApiTokens, HasFactory;
 
     public $timestamps = false;
+    public $incrementing = false;
 
     /**
      * The primary key associated with the table.
@@ -48,6 +52,12 @@ class User extends Authenticatable
      */
     public function banned(){
         return $this->hasOne(BannedUser::class);
+    }
+
+    public function groups(): BelongsToMany
+    {
+        return $this->belongsToMany(Group::class, 'group_user')
+            ->withPivot('added_by', 'created_at');
     }
 
      /**

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,11 @@
             "Database\\Seeders\\": "database/seeders/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "prefer-stable": true,
     "scripts": {
         "post-autoload-dump": [

--- a/database/factories/GroupAttributeDefinitionFactory.php
+++ b/database/factories/GroupAttributeDefinitionFactory.php
@@ -1,0 +1,18 @@
+<?php
+namespace Database\Factories;
+
+use App\Models\GroupAttributeDefinition;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GroupAttributeDefinitionFactory extends Factory
+{
+    protected $model = GroupAttributeDefinition::class;
+
+    public function definition(): array
+    {
+        return [
+            'key' => $this->faker->unique()->lexify('attr_????'),
+            'label' => $this->faker->words(2, true),
+        ];
+    }
+}

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -1,0 +1,25 @@
+<?php
+namespace Database\Factories;
+
+use App\Models\Group;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GroupFactory extends Factory
+{
+    protected $model = Group::class;
+
+    public function definition(): array
+    {
+        return [
+            'slug' => $this->faker->unique()->slug(2),
+            'name' => $this->faker->unique()->words(3, true),
+            'description' => $this->faker->optional()->sentence(),
+            'is_admin_group' => false,
+        ];
+    }
+
+    public function admin(): static
+    {
+        return $this->state(['is_admin_group' => true]);
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,29 +1,29 @@
 <?php
-
-namespace Database\Seeders;
+namespace Database\Factories;
 
 use App\User;
-use Faker\Generator as Faker;
-use Illuminate\Support\Str;
-use Illuminate\Database\Seeder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-/*
-|--------------------------------------------------------------------------
-| Model Factories
-|--------------------------------------------------------------------------
-|
-| This directory should contain each of the model factory definitions for
-| your application. Factories provide a convenient way to generate new
-| model instances for testing / seeding your application's database.
-|
-*/
+class UserFactory extends Factory
+{
+    protected $model = User::class;
 
-$factory->define(User::class, function (Faker $faker) {
-    return [
-        'name' => $faker->name,
-        'email' => $faker->unique()->safeEmail,
-        'email_verified_at' => now(),
-        'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-        'remember_token' => Str::random(10),
-    ];
-});
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->unique()->numberBetween(1000000, 2000000000),
+            'email' => $this->faker->unique()->safeEmail(),
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'rating' => 1,
+            'rating_short' => 'OBS',
+            'rating_long' => 'Observer',
+            'pilot_rating' => 'P0',
+            'pilot_rating_short' => 'P0',
+            'pilot_rating_long' => 'No Pilot Rating',
+            'region' => 'EUR',
+            'division' => 'EUD',
+            'accepted_privacy' => 1,
+        ];
+    }
+}

--- a/database/migrations/2026_05_26_000001_create_groups_table.php
+++ b/database/migrations/2026_05_26_000001_create_groups_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('groups', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('slug', 64)->unique();
+            $table->string('name', 255);
+            $table->text('description')->nullable();
+            $table->boolean('is_admin_group')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('groups');
+    }
+};

--- a/database/migrations/2026_05_26_000002_create_group_tags_table.php
+++ b/database/migrations/2026_05_26_000002_create_group_tags_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_tags', function (Blueprint $table) {
+            $table->uuid('group_id');
+            $table->string('tag', 32);
+            $table->primary(['group_id', 'tag']);
+            $table->index('tag');
+            $table->foreign('group_id')->references('id')->on('groups')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_tags');
+    }
+};

--- a/database/migrations/2026_05_26_000003_create_group_attribute_definitions_table.php
+++ b/database/migrations/2026_05_26_000003_create_group_attribute_definitions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_attribute_definitions', function (Blueprint $table) {
+            $table->id();
+            $keyCol = $table->string('key', 32)->unique();
+            if (DB::getDriverName() === 'mysql') {
+                $keyCol->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
+            }
+            $table->string('label', 255);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_attribute_definitions');
+    }
+};

--- a/database/migrations/2026_05_26_000004_create_group_attribute_values_table.php
+++ b/database/migrations/2026_05_26_000004_create_group_attribute_values_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_attribute_values', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('group_id');
+            $table->unsignedBigInteger('attribute_definition_id');
+            $table->string('value', 255);
+            $table->unique(['group_id', 'attribute_definition_id']);
+            $table->index(['attribute_definition_id', 'value']);
+            $table->foreign('group_id')->references('id')->on('groups')->onDelete('cascade');
+            $table->foreign('attribute_definition_id')
+                ->references('id')->on('group_attribute_definitions')
+                ->onDelete('restrict');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_attribute_values');
+    }
+};

--- a/database/migrations/2026_05_26_000005_create_group_user_table.php
+++ b/database/migrations/2026_05_26_000005_create_group_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_user', function (Blueprint $table) {
+            $table->uuid('group_id');
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('added_by')->nullable();
+            $table->timestamp('created_at')->nullable();
+            $table->primary(['group_id', 'user_id']);
+            $table->index('user_id');
+            $table->foreign('group_id')->references('id')->on('groups')->onDelete('restrict');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('added_by')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_user');
+    }
+};

--- a/database/migrations/2026_05_26_000006_create_group_manager_rules_by_group_table.php
+++ b/database/migrations/2026_05_26_000006_create_group_manager_rules_by_group_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_manager_rules_by_group', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('manager_group_id');
+            $table->uuid('target_group_id');
+            $table->unique(['manager_group_id', 'target_group_id'], 'gmr_by_group_unique');
+            $table->timestamps();
+            $table->foreign('manager_group_id')->references('id')->on('groups')->onDelete('cascade');
+            $table->foreign('target_group_id')->references('id')->on('groups')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_manager_rules_by_group');
+    }
+};

--- a/database/migrations/2026_05_26_000007_create_group_manager_rules_by_tag_table.php
+++ b/database/migrations/2026_05_26_000007_create_group_manager_rules_by_tag_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_manager_rules_by_tag', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('manager_group_id');
+            $table->string('target_tag', 32);
+            $table->unique(['manager_group_id', 'target_tag'], 'gmr_by_tag_unique');
+            $table->timestamps();
+            $table->foreign('manager_group_id')->references('id')->on('groups')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_manager_rules_by_tag');
+    }
+};

--- a/database/migrations/2026_05_26_000008_create_group_manager_rules_by_attribute_table.php
+++ b/database/migrations/2026_05_26_000008_create_group_manager_rules_by_attribute_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('group_manager_rules_by_attribute', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('manager_group_id');
+            $keyCol = $table->string('target_attribute_key', 32);
+            if (DB::getDriverName() === 'mysql') {
+                $keyCol->charset('utf8mb4')->collation('utf8mb4_unicode_ci');
+            }
+            $table->string('target_attribute_value', 255);
+            $table->unique(['manager_group_id', 'target_attribute_key', 'target_attribute_value'], 'gmr_by_attr_unique');
+            $table->timestamps();
+            $table->foreign('manager_group_id')->references('id')->on('groups')->onDelete('cascade');
+            $table->foreign('target_attribute_key')
+                ->references('key')
+                ->on('group_attribute_definitions')
+                ->onDelete('restrict');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('group_manager_rules_by_attribute');
+    }
+};

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,0 +1,62 @@
+# Groups
+
+The groups system is a general-purpose membership and delegation layer. Administrators define named groups, assign users to them, and write rules that let certain groups manage the membership of others. Client applications can request the `groups` OAuth scope to receive a user's group memberships via `GET /api/user`.
+
+---
+
+## How it works
+
+A group has a slug, an optional description, tags, and attribute values. Tags are free-form strings; attributes are key/value pairs drawn from a global schema of attribute definitions (e.g. `region`, `division`). Any number of groups can be marked as admin groups — members of those groups have full system access.
+
+Manager rules control delegation. A rule says that members of one group (the manager group) can manage the membership of other groups. Rules can match by a specific target group, by tag (any group carrying a given tag), or by attribute value (any group whose attribute matches a key/value pair). Tag and attribute rules are global: they match every group that satisfies the pattern, including ones created in the future.
+
+Manager access is resolved at request time by checking whether any rule points at the requested group through the user's own memberships. The result is cached per user with a 5-minute TTL and invalidated whenever memberships or rules change.
+
+---
+
+## Access
+
+There are three access levels. System administrators (members of any `is_admin_group` group) have full CRUD over groups, memberships, rules, and attribute definitions. Group managers can add and remove members of the groups their rules cover, but cannot edit group metadata or rules. Everyone else can view their own memberships via the API.
+
+The web interface lives under `/groups`. Managers see only the groups they can manage; admins see everything. A global rules overview at `/groups/rules` shows every delegation rule across all groups in one place.
+
+---
+
+## API
+
+Requesting the `groups` scope appends a `groups` array to the `/api/user` response:
+
+```json
+{
+  "cid": 1234567,
+  "personal": { "...": "..." },
+  "groups": [
+    {
+      "id": "018f1e2a-7c3d-7000-8000-abcdef012345",
+      "slug": "vacc-norway",
+      "name": "vACC Norway",
+      "tags": ["vacc", "eur"],
+      "attributes": {
+        "region": "EUR",
+        "division": "EUD"
+      }
+    }
+  ]
+}
+```
+
+Use `id` (UUIDv7) as the stable canonical reference in client applications. `slug` is human-readable but not guaranteed to stay the same. Tags and attributes carry no API stability contract.
+
+---
+
+## Use-cases
+
+To gate access in a client application, create a group, add members, and check `groups[*].id` in the API response. No hard-coded roles required.
+
+To delegate roster management without granting full admin access, create a group for the managers (e.g. "vACC Directors") and a tag-match rule granting it management of every group tagged `vacc`. Any future group with that tag is automatically covered.
+
+To manage a whole region or division uniformly, assign a shared attribute (e.g. `region = EUR`) to the relevant groups and write one attribute-match rule. The managing group gains access to all matching groups past and future.
+
+Manager rules can be mutual or self-referential, which supports federated governance patterns where groups co-administer each other.
+
+To bootstrap the first administrator, run `php artisan groups:add-admin {cid}`. This finds or creates a `system-administrators` admin group and adds the user to it.

--- a/resources/views/components/card-header.blade.php
+++ b/resources/views/components/card-header.blade.php
@@ -1,0 +1,9 @@
+{{-- Responsive card header: title content on the left, optional action buttons
+     (via the `actions` slot) on the right. On narrow screens the two clusters
+     stack vertically and the buttons wrap instead of overflowing. --}}
+<div {{ $attributes->merge(['class' => 'card-header d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2']) }}>
+    <div>{{ $slot }}</div>
+    @if(isset($actions) && ! $actions->isEmpty())
+        <div class="d-flex flex-wrap gap-2">{{ $actions }}</div>
+    @endif
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -10,7 +10,15 @@
         <i class="fas fa-info-circle"></i>&nbsp;To delete your personal data contact the <a href="mailto:{{ Config::get('app.dpo_mail') }}">Data Protection Officer</a>.
     </div>
 
-    <a href="{{route('logout')}}" class="btn btn btn-primary">Logout</a>
+    <div class="d-flex flex-column justify-content-center align-items-center gap-3">
+        <a href="{{route('logout')}}" class="btn btn btn-primary">Logout</a>
+
+        @can('viewAny', \App\Models\Group::class)
+            <a href="{{ route('groups.index') }}" class="btn btn-outline-secondary" style="font-size: 14px;">
+                <i class="fas fa-users-cog"></i>&nbsp;Manage groups
+            </a>
+        @endcan
+    </div>
 @endsection
 
 @section('js')

--- a/resources/views/groups/_form.blade.php
+++ b/resources/views/groups/_form.blade.php
@@ -1,0 +1,49 @@
+<div class="mb-3">
+    <label class="form-label">Slug</label>
+    <input type="text" name="slug" class="form-control" value="{{ old('slug', $group?->slug) }}" required pattern="[a-z0-9-]+" maxlength="64">
+    <div class="form-text">Lowercase letters, numbers, hyphens only. Not guaranteed stable.</div>
+</div>
+<div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="{{ old('name', $group?->name) }}" required maxlength="255">
+</div>
+<div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" maxlength="1000">{{ old('description', $group?->description) }}</textarea>
+</div>
+<div class="mb-3">
+    <label class="form-label">Tags <small class="text-muted">(comma-separated, e.g. vacc,eur)</small></label>
+    <input type="text" name="tags_input" class="form-control" value="{{ old('tags_input', $group?->tags->pluck('tag')->join(',')) }}" id="tagsInput">
+    <div id="tagsHidden"></div>
+</div>
+@if($definitions->isNotEmpty())
+<div class="mb-3">
+    <label class="form-label">Attributes</label>
+    @foreach($definitions as $def)
+    <div class="input-group mb-1">
+        <span class="input-group-text" style="min-width:120px"><code>{{ $def->key }}</code></span>
+        <input type="text" name="attributes[{{ $def->id }}]" class="form-control"
+               value="{{ old("attributes.{$def->id}", $group?->attributeValues->firstWhere('attribute_definition_id', $def->id)?->value) }}"
+               placeholder="{{ $def->label }}" maxlength="255">
+    </div>
+    @endforeach
+</div>
+@endif
+<div class="mb-3 form-check">
+    <input type="hidden" name="is_admin_group" value="0">
+    <input type="checkbox" name="is_admin_group" value="1" class="form-check-input" id="isAdminGroup"
+           {{ old('is_admin_group', $group?->is_admin_group) ? 'checked' : '' }}>
+    <label class="form-check-label" for="isAdminGroup">Admin group <small class="text-muted">(members get full system access)</small></label>
+</div>
+<script>
+    document.getElementById('tagsInput').addEventListener('input', function() {
+        const container = document.getElementById('tagsHidden');
+        container.innerHTML = '';
+        this.value.split(',').map(t => t.trim().toLowerCase()).filter(Boolean).forEach(tag => {
+            const input = document.createElement('input');
+            input.type = 'hidden'; input.name = 'tags[]'; input.value = tag;
+            container.appendChild(input);
+        });
+    });
+    document.getElementById('tagsInput').dispatchEvent(new Event('input'));
+</script>

--- a/resources/views/groups/attributes.blade.php
+++ b/resources/views/groups/attributes.blade.php
@@ -1,0 +1,73 @@
+@extends('layouts.admin')
+
+@section('content')
+<div class="card mb-4">
+    <x-card-header>
+        <strong>Attribute Definitions</strong>
+        <x-slot:actions>
+            <a href="{{ route('groups.index') }}" class="btn btn-sm btn-outline-secondary">← Groups</a>
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body">
+        <form method="POST" action="{{ route('groups.attributes.store') }}" class="row g-2 mb-4">
+            @csrf
+            <div class="col-md-4">
+                <input type="text" name="key" class="form-control" placeholder="key (e.g. region)" value="{{ old('key') }}" required pattern="[a-z0-9_-]+">
+            </div>
+            <div class="col-md-6">
+                <input type="text" name="label" class="form-control" placeholder="Label (e.g. Region)" value="{{ old('label') }}" required>
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-primary w-100">Add</button>
+            </div>
+        </form>
+
+        <div class="table-responsive">
+        <table class="table table-sm">
+            <thead><tr><th>Key</th><th>Label</th><th></th></tr></thead>
+            <tbody>
+                @forelse($definitions as $def)
+                <tr id="row-{{ $def->id }}">
+                    <td><code>{{ $def->key }}</code></td>
+                    <td>{{ $def->label }}</td>
+                    <td class="text-end">
+                        <button type="button" class="btn btn-sm btn-outline-secondary me-1"
+                            onclick="toggleEdit({{ $def->id }})">Edit</button>
+                        <form method="POST" action="{{ route('groups.attributes.destroy', $def) }}"
+                            onsubmit="return confirm('Delete this definition?')" class="d-inline">
+                            @csrf @method('DELETE')
+                            <button class="btn btn-sm btn-outline-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                <tr id="edit-{{ $def->id }}" style="display:none">
+                    <td><code>{{ $def->key }}</code></td>
+                    <td colspan="2">
+                        <form method="POST" action="{{ route('groups.attributes.update', $def) }}"
+                            class="d-flex gap-2">
+                            @csrf @method('PATCH')
+                            <input type="text" name="label" class="form-control form-control-sm"
+                                value="{{ $def->label }}" required maxlength="255">
+                            <button class="btn btn-sm btn-primary">Save</button>
+                            <button type="button" class="btn btn-sm btn-outline-secondary"
+                                onclick="toggleEdit({{ $def->id }})">Cancel</button>
+                        </form>
+                    </td>
+                </tr>
+                @empty
+                <tr><td colspan="3" class="text-muted">No attribute definitions yet.</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+        </div>
+    </div>
+</div>
+<script>
+function toggleEdit(id) {
+    document.getElementById('row-' + id).style.display =
+        document.getElementById('row-' + id).style.display === 'none' ? '' : 'none';
+    document.getElementById('edit-' + id).style.display =
+        document.getElementById('edit-' + id).style.display === 'none' ? '' : 'none';
+}
+</script>
+@endsection

--- a/resources/views/groups/create.blade.php
+++ b/resources/views/groups/create.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <strong>New Group</strong>
+        <x-slot:actions>
+            <a href="{{ route('groups.index') }}" class="btn btn-sm btn-outline-secondary">← Groups</a>
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body">
+        <form method="POST" action="{{ route('groups.store') }}">
+            @csrf
+            @include('groups._form', ['group' => null])
+            <button class="btn btn-primary">Create Group</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <strong>Edit: {{ $group->name }}</strong>
+        <x-slot:actions>
+            <a href="{{ route('groups.show', $group) }}" class="btn btn-sm btn-outline-secondary">← Back</a>
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body">
+        <form method="POST" action="{{ route('groups.update', $group) }}">
+            @csrf @method('PATCH')
+            @include('groups._form', ['group' => $group])
+            <button class="btn btn-primary">Save Changes</button>
+        </form>
+
+        <hr>
+        <form method="POST" action="{{ route('groups.destroy', $group) }}" onsubmit="return confirm('Delete this group? It must have no members.')">
+            @csrf @method('DELETE')
+            <button class="btn btn-outline-danger btn-sm">Delete Group</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <strong>Groups</strong>
+        @if($isAdmin)
+            <span class="badge bg-danger ms-2">System Administrator</span>
+        @else
+            <span class="badge bg-secondary ms-2">Group Manager</span>
+        @endif
+        <x-slot:actions>
+            @if($isAdmin)
+            <a href="{{ route('groups.rules.overview') }}" class="btn btn-sm btn-outline-secondary">Manager Rules</a>
+            <a href="{{ route('groups.attributes.index') }}" class="btn btn-sm btn-outline-secondary">Attribute Definitions</a>
+            <a href="{{ route('groups.create') }}" class="btn btn-sm btn-primary">New Group</a>
+            @endif
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-sm mb-0">
+                <thead><tr><th>Slug</th><th>Name</th><th>Tags</th><th>Members</th><th>Admin</th><th></th></tr></thead>
+                <tbody>
+                    @forelse($groups as $group)
+                    <tr>
+                        <td><code>{{ $group->slug }}</code></td>
+                        <td>{{ $group->name }}</td>
+                        <td>{{ $group->tags->pluck('tag')->join(', ') }}</td>
+                        <td>{{ $group->members_count }}</td>
+                        <td>{{ $group->is_admin_group ? '✓' : '' }}</td>
+                        <td class="text-end">
+                            <a href="{{ route('groups.show', $group) }}" class="btn btn-sm btn-outline-primary">View</a>
+                        </td>
+                    </tr>
+                    @empty
+                    <tr><td colspan="6" class="text-muted p-3">No groups yet.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+    @if($groups->hasPages())
+    <div class="card-footer">{{ $groups->links() }}</div>
+    @endif
+</div>
+@endsection

--- a/resources/views/groups/members.blade.php
+++ b/resources/views/groups/members.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <strong>{{ $group->name }} — Members</strong>
+        <x-slot:actions>
+            <a href="{{ route('groups.show', $group) }}" class="btn btn-sm btn-outline-secondary">← Group</a>
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body">
+        <h6>Add Member</h6>
+        <form method="POST" action="{{ route('groups.members.store', $group) }}" class="row g-2 mb-3">
+            @csrf
+            <div class="col-md-6">
+                <input type="number" name="cid" class="form-control" placeholder="VATSIM CID" required>
+            </div>
+            <div class="col-md-3">
+                <button class="btn btn-primary w-100">Add Member</button>
+            </div>
+        </form>
+
+        <h6 class="mt-4">Find Members</h6>
+        <form method="GET" class="row g-2 mb-3">
+            <div class="col-md-6">
+                <input type="text" name="search" class="form-control" placeholder="Search by name or CID" value="{{ $search ?? '' }}">
+            </div>
+            <div class="col-md-3"><button class="btn btn-outline-secondary w-100">Search</button></div>
+            @if($search) <div class="col-auto"><a href="{{ route('groups.members.index', $group) }}" class="btn btn-outline-secondary">Clear</a></div> @endif
+        </form>
+
+        <div class="table-responsive">
+            <table class="table table-sm">
+                <thead><tr><th>CID</th><th>Name</th><th>Email</th><th></th></tr></thead>
+                <tbody>
+                    @forelse($members as $member)
+                    <tr>
+                        <td>{{ $member->id }}</td>
+                        <td>{{ $member->first_name }} {{ $member->last_name }}</td>
+                        <td>{{ $member->email }}</td>
+                        <td class="text-end">
+                            <form method="POST" action="{{ route('groups.members.destroy', [$group, $member]) }}" onsubmit="return confirm('Remove this member?')">
+                                @csrf @method('DELETE')
+                                <button class="btn btn-sm btn-outline-danger">Remove</button>
+                            </form>
+                        </td>
+                    </tr>
+                    @empty
+                    <tr><td colspan="4" class="text-muted">No members{{ $search ? ' matching your search' : '' }}.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        {{ $members->links() }}
+    </div>
+</div>
+@endsection

--- a/resources/views/groups/rules-overview.blade.php
+++ b/resources/views/groups/rules-overview.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <strong>Manager Rules</strong>
+        <x-slot:actions>
+            <a href="{{ route('groups.index') }}" class="btn btn-sm btn-outline-secondary">← Groups</a>
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+        <table class="table table-sm mb-0">
+            <thead>
+                <tr>
+                    <th>Manager Group</th>
+                    <th>Type</th>
+                    <th>Grants management of</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($rules as $entry)
+                @php $rule = $entry['rule']; @endphp
+                <tr>
+                    <td>
+                        <a href="{{ route('groups.show', $entry['manager']) }}">{{ $entry['manager']->name }}</a>
+                    </td>
+                    <td>
+                        @if($entry['type'] === 'group') Specific group
+                        @elseif($entry['type'] === 'tag') Tag match
+                        @else Attribute match
+                        @endif
+                    </td>
+                    <td>
+                        @if($entry['type'] === 'group')
+                            <a href="{{ route('groups.show', $rule->targetGroup) }}">{{ $rule->targetGroup->name }}</a>
+                        @elseif($entry['type'] === 'tag')
+                            Groups tagged <code>{{ $rule->target_tag }}</code>
+                        @else
+                            Groups where <code>{{ $rule->target_attribute_key }}</code> = <code>{{ $rule->target_attribute_value }}</code>
+                        @endif
+                    </td>
+                    <td class="text-end">
+                        @if($entry['type'] === 'group')
+                            <a href="{{ route('groups.rules.index', $rule->targetGroup) }}" class="btn btn-sm btn-outline-secondary me-1">Rules page</a>
+                        @endif
+                        <form method="POST"
+                            action="{{ route('groups.rules.overview.destroy', [$entry['type'], $rule->id]) }}"
+                            onsubmit="return confirm('Remove this rule?')"
+                            class="d-inline">
+                            @csrf @method('DELETE')
+                            <button class="btn btn-sm btn-outline-danger">Remove</button>
+                        </form>
+                    </td>
+                </tr>
+                @empty
+                <tr><td colspan="4" class="text-muted p-3">No manager rules defined yet.</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/groups/rules.blade.php
+++ b/resources/views/groups/rules.blade.php
@@ -1,0 +1,105 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <strong>{{ $group->name }} — Manager Rules</strong>
+        <x-slot:actions>
+            <a href="{{ route('groups.show', $group) }}" class="btn btn-sm btn-outline-secondary">← Group</a>
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body">
+
+        <h6>Add Rule</h6>
+        <form method="POST" action="{{ route('groups.rules.store', $group) }}" class="row g-2 mb-4">
+            @csrf
+            <div class="col-md-3">
+                <select name="type" class="form-select" id="ruleType" onchange="updateRuleFields()">
+                    <option value="group">Specific group</option>
+                    <option value="tag">Tag match</option>
+                    <option value="attribute">Attribute match</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <select name="manager_group_id" class="form-select">
+                    @foreach($allGroups as $g)
+                    <option value="{{ $g->id }}">{{ $g->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-md-4" id="ruleFields">
+                <input type="hidden" name="target_group_id" value="{{ $group->id }}" id="fieldGroupId">
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-primary w-100">Add Rule</button>
+            </div>
+        </form>
+
+        <h6>Rules granting management of this group</h6>
+        <div class="table-responsive">
+        <table class="table table-sm">
+            <thead><tr><th>Type</th><th>Manager Group</th><th>Matches via</th><th></th></tr></thead>
+            <tbody>
+                @foreach($group->targetedByGroupRules as $rule)
+                <tr>
+                    <td>Group</td>
+                    <td>{{ $rule->managerGroup->name }}</td>
+                    <td><em>direct rule</em></td>
+                    <td class="text-end">
+                        <form method="POST" action="{{ route('groups.rules.destroy', [$group, 'group', $rule->id]) }}">
+                            @csrf @method('DELETE')
+                            <button class="btn btn-sm btn-outline-danger">Remove</button>
+                        </form>
+                    </td>
+                </tr>
+                @endforeach
+                @foreach($tagRules as $rule)
+                <tr>
+                    <td>Tag</td>
+                    <td>{{ $rule->managerGroup->name }}</td>
+                    <td>tag = <code>{{ $rule->target_tag }}</code></td>
+                    <td class="text-end">
+                        <form method="POST" action="{{ route('groups.rules.destroy', [$group, 'tag', $rule->id]) }}">
+                            @csrf @method('DELETE')
+                            <button class="btn btn-sm btn-outline-danger">Remove</button>
+                        </form>
+                    </td>
+                </tr>
+                @endforeach
+                @foreach($attrRules as $rule)
+                <tr>
+                    <td>Attribute</td>
+                    <td>{{ $rule->managerGroup->name }}</td>
+                    <td><code>{{ $rule->target_attribute_key }}</code> = <code>{{ $rule->target_attribute_value }}</code></td>
+                    <td class="text-end">
+                        <form method="POST" action="{{ route('groups.rules.destroy', [$group, 'attribute', $rule->id]) }}">
+                            @csrf @method('DELETE')
+                            <button class="btn btn-sm btn-outline-danger">Remove</button>
+                        </form>
+                    </td>
+                </tr>
+                @endforeach
+                @if($group->targetedByGroupRules->isEmpty() && $tagRules->isEmpty() && $attrRules->isEmpty())
+                <tr><td colspan="4" class="text-muted">No rules yet — this group is not managed by anyone.</td></tr>
+                @endif
+            </tbody>
+        </table>
+        </div>
+    </div>
+</div>
+<script>
+const attrDefs = @json($definitions->map(fn($d) => ['key' => $d->key]));
+function updateRuleFields() {
+    const type = document.getElementById('ruleType').value;
+    const container = document.getElementById('ruleFields');
+    if (type === 'group') {
+        container.innerHTML = '<input type="hidden" name="target_group_id" value="{{ $group->id }}">';
+    } else if (type === 'tag') {
+        container.innerHTML = '<input type="text" name="target_tag" class="form-control" placeholder="tag (e.g. vacc)" pattern="[a-z0-9-]+" required>';
+    } else {
+        const keyOpts = attrDefs.map(d => `<option value="${d.key}">${d.key}</option>`).join('');
+        container.innerHTML = `<div class="input-group"><select name="target_attribute_key" class="form-select">${keyOpts}</select><input type="text" name="target_attribute_value" class="form-control" placeholder="value" required></div>`;
+    }
+}
+updateRuleFields();
+</script>
+@endsection

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.admin')
+@section('content')
+<div class="card">
+    <x-card-header>
+        <div class="d-flex align-items-center gap-2">
+            <div>
+                <strong>{{ $group->name }}</strong>
+                <div><code class="text-muted">{{ $group->slug }}</code></div>
+            </div>
+            @if($group->is_admin_group)
+                <span class="badge bg-danger">Admin</span>
+            @endif
+        </div>
+        <x-slot:actions>
+            <a href="{{ route('groups.index') }}" class="btn btn-sm btn-outline-secondary">← Groups</a>
+            <a href="{{ route('groups.members.index', $group) }}" class="btn btn-sm btn-outline-primary">Members</a>
+            @if($isAdmin)
+            <a href="{{ route('groups.rules.index', $group) }}" class="btn btn-sm btn-outline-secondary">Rules</a>
+            <a href="{{ route('groups.edit', $group) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+            @endif
+        </x-slot:actions>
+    </x-card-header>
+    <div class="card-body">
+        @if($group->description)
+        <p>{{ $group->description }}</p>
+        @endif
+
+        @if($group->tags->isNotEmpty())
+        <p><strong>Tags:</strong>
+            @foreach($group->tags as $tag)
+            <span class="badge bg-secondary">{{ $tag->tag }}</span>
+            @endforeach
+        </p>
+        @endif
+
+        @if($group->attributeValues->isNotEmpty())
+        <div class="table-responsive">
+            <table class="table table-sm w-auto">
+                <thead><tr><th>Attribute</th><th>Value</th></tr></thead>
+                <tbody>
+                    @foreach($group->attributeValues as $av)
+                    <tr>
+                        <td><code>{{ $av->definition->key }}</code></td>
+                        <td>{{ $av->value }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
+
+        @if($isAdmin)
+        <div class="mt-3 text-muted" style="font-size:13px">
+            <span class="badge bg-danger">System Administrator</span> You have full administrative access.
+        </div>
+        @elseif(!empty($grantingRules))
+        <div class="mt-3 text-muted" style="font-size:13px">
+            <span class="badge bg-secondary">Group Manager</span> <strong>Your access is granted by:</strong>
+            <ul class="mb-0">@foreach($grantingRules as $rule)<li>{{ $rule }}</li>@endforeach</ul>
+        </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta name="robots" content="noindex">
+    <title>{{ config('app.name', 'Handover') }} — Groups</title>
+    <link rel="icon" href="{{ URL::asset('/favicon.ico') }}" type="image/x-icon"/>
+    @vite(['resources/sass/app.scss', 'resources/js/app.js'])
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+</head>
+<body>
+    <div class="bg-primary min-vh-100 pb-4">
+        <div class="container-md">
+            <div class="row justify-content-center pt-4 pb-2">
+                <div class="col-lg-10 col-md-12">
+                    <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center gap-2 mb-3">
+                        <div class="d-flex align-items-center gap-3">
+                            <a href="{{ env('APP_URL') }}" class="text-white text-decoration-none">
+                                <strong>{{ config('app.name', 'Handover') }}</strong>
+                            </a>
+                            <a href="{{ route('groups.index') }}" class="text-white text-decoration-none" style="font-size: 14px;">Groups</a>
+                        </div>
+                        <div class="text-white" style="font-size: 12px;">
+                            {{ Auth::user()->first_name }} {{ Auth::user()->last_name }}
+                            <span class="d-none d-sm-inline">({{ Auth::user()->id }})</span>
+                            &mdash; <a href="{{ route('logout') }}" class="text-white">Logout</a>
+                        </div>
+                    </div>
+
+                    @if(Session::has('success'))
+                        <div class="alert alert-success">{{ Session::pull('success') }}</div>
+                    @endif
+
+                    @if($errors->any())
+                        <div class="alert alert-danger">
+                            <ul class="mb-0">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @yield('content')
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,10 @@
 <?php
 
+use App\Http\Controllers\GroupAttributeDefinitionController;
+use App\Http\Controllers\GroupController;
+use App\Http\Controllers\GroupManagerRuleController;
+use App\Http\Controllers\GroupMemberController;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -15,6 +20,41 @@ Route::namespace('Auth')->group(function () {
     Route::get('/login', 'LoginController@login')->middleware('guest')->name('login');
     Route::get('/validate', 'LoginController@validateLogin')->middleware('guest');
     Route::get('/logout', 'LoginController@logout')->middleware('auth')->name('logout');
+});
+
+Route::middleware(['auth', 'groups.manage'])->prefix('groups')->name('groups.')->group(function () {
+    // Fixed segments first — must come before {group} wildcard
+    Route::get('attributes', [GroupAttributeDefinitionController::class, 'index'])->name('attributes.index');
+    Route::post('attributes', [GroupAttributeDefinitionController::class, 'store'])->name('attributes.store');
+    Route::patch('attributes/{definition}', [GroupAttributeDefinitionController::class, 'update'])->name('attributes.update');
+    Route::delete('attributes/{definition}', [GroupAttributeDefinitionController::class, 'destroy'])->name('attributes.destroy');
+
+    Route::get('rules', [GroupManagerRuleController::class, 'overview'])->name('rules.overview');
+    Route::delete('rules/{type}/{rule}', [GroupManagerRuleController::class, 'destroyFromOverview'])
+        ->name('rules.overview.destroy')
+        ->where('type', 'group|tag|attribute')
+        ->where('rule', '[0-9]+');
+
+    Route::get('create', [GroupController::class, 'create'])->name('create');
+    Route::post('/', [GroupController::class, 'store'])->name('store');
+    Route::get('/', [GroupController::class, 'index'])->name('index');
+
+    // {group} wildcard routes — bound by slug via Group::getRouteKeyName()
+    Route::get('{group}', [GroupController::class, 'show'])->name('show');
+    Route::get('{group}/edit', [GroupController::class, 'edit'])->name('edit');
+    Route::patch('{group}', [GroupController::class, 'update'])->name('update');
+    Route::delete('{group}', [GroupController::class, 'destroy'])->name('destroy');
+
+    Route::get('{group}/members', [GroupMemberController::class, 'index'])->name('members.index');
+    Route::post('{group}/members', [GroupMemberController::class, 'store'])->name('members.store');
+    Route::delete('{group}/members/{user}', [GroupMemberController::class, 'destroy'])->name('members.destroy');
+
+    Route::get('{group}/rules', [GroupManagerRuleController::class, 'index'])->name('rules.index');
+    Route::post('{group}/rules', [GroupManagerRuleController::class, 'store'])->name('rules.store');
+    Route::delete('{group}/rules/{type}/{rule}', [GroupManagerRuleController::class, 'destroy'])
+        ->name('rules.destroy')
+        ->where('type', 'group|tag|attribute')
+        ->where('rule', '[0-9]+');
 });
 
 Route::middleware(['suspended'])->group(function () {

--- a/tests/Feature/Groups/AddGroupAdminCommandTest.php
+++ b/tests/Feature/Groups/AddGroupAdminCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AddGroupAdminCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creates_admin_group_and_adds_user(): void
+    {
+        $user = User::factory()->create(['id' => 1234567]);
+
+        $this->artisan('groups:add-admin', ['cid' => 1234567])
+            ->assertExitCode(0);
+
+        $group = Group::where('slug', 'system-administrators')->first();
+        $this->assertNotNull($group);
+        $this->assertTrue($group->is_admin_group);
+        $this->assertTrue($group->members()->where('user_id', 1234567)->exists());
+    }
+
+    public function test_reuses_existing_admin_group(): void
+    {
+        $user = User::factory()->create(['id' => 1234567]);
+        Group::factory()->admin()->create(['slug' => 'system-administrators']);
+
+        $this->artisan('groups:add-admin', ['cid' => 1234567])
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, Group::where('slug', 'system-administrators')->count());
+    }
+
+    public function test_is_idempotent_when_user_already_member(): void
+    {
+        $user = User::factory()->create(['id' => 1234567]);
+        $group = Group::factory()->admin()->create(['slug' => 'system-administrators']);
+        $group->members()->attach(1234567, ['created_at' => now()]);
+
+        $this->artisan('groups:add-admin', ['cid' => 1234567])
+            ->assertExitCode(0);
+
+        $this->assertEquals(1, $group->members()->where('user_id', 1234567)->count());
+    }
+
+    public function test_fails_when_user_not_found(): void
+    {
+        $this->artisan('groups:add-admin', ['cid' => 9999999])
+            ->assertExitCode(1);
+    }
+
+    public function test_fails_when_slug_exists_but_is_not_admin_group(): void
+    {
+        User::factory()->create(['id' => 1234567]);
+        Group::factory()->create(['slug' => 'system-administrators', 'is_admin_group' => false]);
+
+        $this->artisan('groups:add-admin', ['cid' => 1234567])
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Feature/Groups/ApiGroupsScopeTest.php
+++ b/tests/Feature/Groups/ApiGroupsScopeTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\Models\GroupAttributeValue;
+use App\Models\GroupTag;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class ApiGroupsScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_groups_not_included_without_scope(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user, ['full_name']);
+
+        $this->getJson('/api/user')
+            ->assertStatus(200)
+            ->assertJsonMissingPath('data.groups');
+    }
+
+    public function test_groups_included_with_scope(): void
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create(['slug' => 'vacc-norway', 'name' => 'vACC Norway']);
+        $group->members()->attach($user->id, ['created_at' => now()]);
+        Passport::actingAs($user, ['groups']);
+
+        $this->getJson('/api/user')
+            ->assertStatus(200)
+            ->assertJsonPath('data.groups.0.slug', 'vacc-norway')
+            ->assertJsonPath('data.groups.0.name', 'vACC Norway')
+            ->assertJsonStructure(['data' => ['groups' => [['id', 'slug', 'name', 'tags', 'attributes']]]]);
+    }
+
+    public function test_groups_response_includes_tags_and_attributes(): void
+    {
+        $user = User::factory()->create();
+        $group = Group::factory()->create(['slug' => 'test-group']);
+        $group->members()->attach($user->id, ['created_at' => now()]);
+        GroupTag::create(['group_id' => $group->id, 'tag' => 'vacc']);
+        $def = GroupAttributeDefinition::factory()->create(['key' => 'region']);
+        GroupAttributeValue::create(['group_id' => $group->id, 'attribute_definition_id' => $def->id, 'value' => 'EUR']);
+        Passport::actingAs($user, ['groups']);
+
+        $response = $this->getJson('/api/user')->assertStatus(200);
+        $groups = $response->json('data.groups');
+        $this->assertEquals(['vacc'], $groups[0]['tags']);
+        $this->assertEquals(['region' => 'EUR'], $groups[0]['attributes']);
+    }
+
+    public function test_user_with_no_groups_gets_empty_array(): void
+    {
+        $user = User::factory()->create();
+        Passport::actingAs($user, ['groups']);
+
+        $this->getJson('/api/user')
+            ->assertStatus(200)
+            ->assertJsonPath('data.groups', []);
+    }
+}

--- a/tests/Feature/Groups/GroupAttributeDefinitionTest.php
+++ b/tests/Feature/Groups/GroupAttributeDefinitionTest.php
@@ -1,0 +1,131 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GroupAttributeDefinitionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        $adminGroup = Group::factory()->admin()->create();
+        $adminGroup->members()->attach($user->id, ['created_at' => now()]);
+        return $user;
+    }
+
+    public function test_non_admin_cannot_access_attribute_definitions(): void
+    {
+        $user = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($user->id, ['created_at' => now()]);
+        \App\Models\GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id' => $targetGroup->id,
+        ]);
+
+        $this->actingAs($user)->get(route('groups.attributes.index'))->assertStatus(403);
+    }
+
+    public function test_admin_can_list_attribute_definitions(): void
+    {
+        GroupAttributeDefinition::factory()->create(['key' => 'region', 'label' => 'Region']);
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.attributes.index'))
+            ->assertStatus(200)
+            ->assertSee('Region');
+    }
+
+    public function test_admin_can_create_attribute_definition(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.attributes.store'), ['key' => 'division', 'label' => 'Division'])
+            ->assertRedirect(route('groups.attributes.index'));
+
+        $this->assertDatabaseHas('group_attribute_definitions', ['key' => 'division']);
+    }
+
+    public function test_key_must_match_allowed_pattern(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.attributes.store'), ['key' => 'INVALID KEY!', 'label' => 'Test'])
+            ->assertSessionHasErrors('key');
+    }
+
+    public function test_admin_can_delete_unused_attribute_definition(): void
+    {
+        $def = GroupAttributeDefinition::factory()->create();
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.attributes.destroy', $def))
+            ->assertRedirect(route('groups.attributes.index'));
+
+        $this->assertDatabaseMissing('group_attribute_definitions', ['id' => $def->id]);
+    }
+
+    public function test_admin_can_update_attribute_label(): void
+    {
+        $def = GroupAttributeDefinition::factory()->create(['key' => 'region', 'label' => 'Region']);
+        $this->actingAs($this->adminUser())
+            ->patch(route('groups.attributes.update', $def), ['label' => 'Geographic Region'])
+            ->assertRedirect(route('groups.attributes.index'));
+
+        $this->assertDatabaseHas('group_attribute_definitions', ['id' => $def->id, 'label' => 'Geographic Region', 'key' => 'region']);
+    }
+
+    public function test_update_label_cannot_be_empty(): void
+    {
+        $def = GroupAttributeDefinition::factory()->create(['label' => 'Region']);
+        $this->actingAs($this->adminUser())
+            ->patch(route('groups.attributes.update', $def), ['label' => ''])
+            ->assertSessionHasErrors('label');
+    }
+
+    public function test_non_admin_cannot_update_attribute_definition(): void
+    {
+        $user = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($user->id, ['created_at' => now()]);
+        \App\Models\GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id' => $targetGroup->id,
+        ]);
+
+        $def = GroupAttributeDefinition::factory()->create(['label' => 'Original']);
+        $this->actingAs($user)
+            ->patch(route('groups.attributes.update', $def), ['label' => 'Changed'])
+            ->assertStatus(403);
+
+        $this->assertDatabaseHas('group_attribute_definitions', ['id' => $def->id, 'label' => 'Original']);
+    }
+
+    public function test_cannot_delete_definition_with_existing_values(): void
+    {
+        $admin = $this->adminUser();
+        $def = GroupAttributeDefinition::factory()->create();
+        $group = Group::factory()->create();
+        \App\Models\GroupAttributeValue::create([
+            'group_id' => $group->id,
+            'attribute_definition_id' => $def->id,
+            'value' => 'test',
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('groups.attributes.destroy', $def))
+            ->assertSessionHasErrors();
+
+        $this->assertDatabaseHas('group_attribute_definitions', ['id' => $def->id]);
+    }
+}

--- a/tests/Feature/Groups/GroupCrudTest.php
+++ b/tests/Feature/Groups/GroupCrudTest.php
@@ -1,0 +1,172 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\Models\GroupManagerRuleByGroup;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class GroupCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        Group::factory()->admin()->create()->members()->attach($user->id, ['created_at' => now()]);
+        return $user;
+    }
+
+    public function test_admin_can_list_groups(): void
+    {
+        Group::factory()->create(['name' => 'vACC Norway']);
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.index'))
+            ->assertStatus(200)
+            ->assertSee('vACC Norway');
+    }
+
+    public function test_manager_sees_only_manageable_groups_on_index(): void
+    {
+        $user = User::factory()->create();
+        $mg = Group::factory()->create(['name' => 'Manager Group']);
+        $tg = Group::factory()->create(['name' => 'Target Group']);
+        $other = Group::factory()->create(['name' => 'Other Group']);
+        $mg->members()->attach($user->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $tg->id]);
+
+        $this->actingAs($user)
+            ->get(route('groups.index'))
+            ->assertStatus(200)
+            ->assertSee('Target Group')
+            ->assertDontSee('Other Group')
+            ->assertDontSee('Manager Group');
+    }
+
+    public function test_admin_can_create_group(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.store'), [
+                'slug' => 'vacc-norway',
+                'name' => 'vACC Norway',
+                'description' => 'Norwegian vACC',
+                'tags' => ['vacc', 'eur'],
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('groups', ['slug' => 'vacc-norway']);
+        $this->assertDatabaseHas('group_tags', ['tag' => 'vacc']);
+        $this->assertDatabaseHas('group_tags', ['tag' => 'eur']);
+    }
+
+    public function test_reserved_slug_is_rejected(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.store'), ['slug' => 'admin', 'name' => 'Test'])
+            ->assertSessionHasErrors('slug');
+    }
+
+    public function test_admin_can_edit_group(): void
+    {
+        $group = Group::factory()->create(['slug' => 'original']);
+        $this->actingAs($this->adminUser())
+            ->patch(route('groups.update', $group), [
+                'slug' => 'updated',
+                'name' => 'Updated Name',
+            ])
+            ->assertRedirect(route('groups.show', 'updated'));
+
+        $this->assertDatabaseHas('groups', ['slug' => 'updated', 'name' => 'Updated Name']);
+    }
+
+    public function test_is_admin_group_toggle_is_logged(): void
+    {
+        Log::shouldReceive('warning')->once()->with('is_admin_group toggled', \Mockery::any());
+        $group = Group::factory()->create(['is_admin_group' => false]);
+        $this->actingAs($this->adminUser())
+            ->patch(route('groups.update', $group), [
+                'slug' => $group->slug,
+                'name' => $group->name,
+                'is_admin_group' => true,
+            ]);
+    }
+
+    public function test_cannot_delete_group_with_members(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create();
+        $group->members()->attach($user->id, ['created_at' => now()]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.destroy', $group))
+            ->assertSessionHasErrors();
+
+        $this->assertDatabaseHas('groups', ['id' => $group->id]);
+    }
+
+    public function test_admin_can_delete_empty_group(): void
+    {
+        $group = Group::factory()->create(['slug' => 'to-delete']);
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.destroy', $group))
+            ->assertRedirect(route('groups.index'));
+
+        $this->assertDatabaseMissing('groups', ['slug' => 'to-delete']);
+    }
+
+    public function test_manager_can_view_group_show(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $tg = Group::factory()->create(['name' => 'Target Group']);
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $tg->id]);
+
+        $this->actingAs($manager)
+            ->get(route('groups.show', $tg))
+            ->assertStatus(200)
+            ->assertSee('Target Group');
+    }
+
+    public function test_manager_cannot_view_unmanaged_group(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $managed = Group::factory()->create();
+        $unmanaged = Group::factory()->create();
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $managed->id]);
+
+        $this->actingAs($manager)
+            ->get(route('groups.show', $unmanaged))
+            ->assertStatus(403);
+    }
+
+    public function test_attribute_values_are_saved_on_create(): void
+    {
+        $def = GroupAttributeDefinition::factory()->create(['key' => 'region']);
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.store'), [
+                'slug' => 'test-group',
+                'name' => 'Test',
+                'attributes' => [$def->id => 'EUR'],
+            ]);
+
+        $group = Group::where('slug', 'test-group')->first();
+        $this->assertNotNull($group);
+        $this->assertDatabaseHas('group_attribute_values', [
+            'group_id' => $group->id,
+            'attribute_definition_id' => $def->id,
+            'value' => 'EUR',
+        ]);
+    }
+}

--- a/tests/Feature/Groups/GroupManagerRuleTest.php
+++ b/tests/Feature/Groups/GroupManagerRuleTest.php
@@ -1,0 +1,271 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\Models\GroupManagerRuleByAttribute;
+use App\Models\GroupManagerRuleByGroup;
+use App\Models\GroupManagerRuleByTag;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GroupManagerRuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        Group::factory()->admin()->create()->members()->attach($user->id, ['created_at' => now()]);
+        return $user;
+    }
+
+    public function test_non_admin_cannot_access_rules_page(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $tg = Group::factory()->create();
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $tg->id]);
+
+        $this->actingAs($manager)->get(route('groups.rules.index', $tg))->assertStatus(403);
+    }
+
+    public function test_admin_can_view_rules_page(): void
+    {
+        $group = Group::factory()->create();
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.rules.index', $group))
+            ->assertStatus(200);
+    }
+
+    public function test_can_add_group_type_rule(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.rules.store', $targetGroup), [
+                'type'             => 'group',
+                'manager_group_id' => $managerGroup->id,
+                'target_group_id'  => $managerGroup->id,
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('group_manager_rules_by_group', [
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id'  => $targetGroup->id,
+        ]);
+    }
+
+    public function test_can_add_tag_type_rule(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.rules.store', $targetGroup), [
+                'type'             => 'tag',
+                'manager_group_id' => $managerGroup->id,
+                'target_tag'       => 'vacc',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('group_manager_rules_by_tag', [
+            'manager_group_id' => $managerGroup->id,
+            'target_tag'       => 'vacc',
+        ]);
+    }
+
+    public function test_can_add_attribute_type_rule(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        GroupAttributeDefinition::factory()->create(['key' => 'region']);
+
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.rules.store', $targetGroup), [
+                'type'                   => 'attribute',
+                'manager_group_id'       => $managerGroup->id,
+                'target_attribute_key'   => 'region',
+                'target_attribute_value' => 'EUR',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('group_manager_rules_by_attribute', [
+            'manager_group_id'       => $managerGroup->id,
+            'target_attribute_key'   => 'region',
+            'target_attribute_value' => 'EUR',
+        ]);
+    }
+
+    public function test_can_delete_group_type_rule(): void
+    {
+        $rule = GroupManagerRuleByGroup::create([
+            'manager_group_id' => Group::factory()->create()->id,
+            'target_group_id'  => Group::factory()->create()->id,
+        ]);
+        $target = Group::find($rule->target_group_id);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.destroy', [$target, 'group', $rule->id]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('group_manager_rules_by_group', ['id' => $rule->id]);
+    }
+
+    public function test_can_delete_tag_type_rule(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $targetGroup->tags()->create(['tag' => 'vacc']);
+        $rule = GroupManagerRuleByTag::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_tag'       => 'vacc',
+        ]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.destroy', [$targetGroup, 'tag', $rule->id]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('group_manager_rules_by_tag', ['id' => $rule->id]);
+    }
+
+    public function test_can_delete_attribute_type_rule(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $def = GroupAttributeDefinition::factory()->create(['key' => 'region']);
+        $targetGroup->attributeValues()->create(['attribute_definition_id' => $def->id, 'value' => 'EUR']);
+        $rule = GroupManagerRuleByAttribute::create([
+            'manager_group_id'       => $managerGroup->id,
+            'target_attribute_key'   => 'region',
+            'target_attribute_value' => 'EUR',
+        ]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.destroy', [$targetGroup, 'attribute', $rule->id]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('group_manager_rules_by_attribute', ['id' => $rule->id]);
+    }
+
+    public function test_overview_can_delete_group_type_rule(): void
+    {
+        $rule = GroupManagerRuleByGroup::create([
+            'manager_group_id' => Group::factory()->create()->id,
+            'target_group_id'  => Group::factory()->create()->id,
+        ]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.overview.destroy', ['group', $rule->id]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('group_manager_rules_by_group', ['id' => $rule->id]);
+    }
+
+    public function test_overview_can_delete_tag_type_rule(): void
+    {
+        $rule = GroupManagerRuleByTag::create([
+            'manager_group_id' => Group::factory()->create()->id,
+            'target_tag'       => 'vacc',
+        ]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.overview.destroy', ['tag', $rule->id]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('group_manager_rules_by_tag', ['id' => $rule->id]);
+    }
+
+    public function test_overview_can_delete_attribute_type_rule(): void
+    {
+        GroupAttributeDefinition::factory()->create(['key' => 'region']);
+        $rule = GroupManagerRuleByAttribute::create([
+            'manager_group_id'       => Group::factory()->create()->id,
+            'target_attribute_key'   => 'region',
+            'target_attribute_value' => 'EUR',
+        ]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.overview.destroy', ['attribute', $rule->id]))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('group_manager_rules_by_attribute', ['id' => $rule->id]);
+    }
+
+    public function test_overview_non_admin_cannot_delete_rule(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $tg = Group::factory()->create();
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        $rule = GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $tg->id]);
+
+        $this->actingAs($manager)
+            ->delete(route('groups.rules.overview.destroy', ['group', $rule->id]))
+            ->assertStatus(403);
+
+        $this->assertDatabaseHas('group_manager_rules_by_group', ['id' => $rule->id]);
+    }
+
+    public function test_cannot_delete_tag_rule_for_unrelated_group(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $targetGroup->tags()->create(['tag' => 'vacc']);
+        $rule = GroupManagerRuleByTag::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_tag'       => 'unrelated-tag',
+        ]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.rules.destroy', [$targetGroup, 'tag', $rule->id]))
+            ->assertStatus(404);
+
+        $this->assertDatabaseHas('group_manager_rules_by_tag', ['id' => $rule->id]);
+    }
+
+    public function test_admin_can_view_overview_page(): void
+    {
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.rules.overview'))
+            ->assertStatus(200);
+    }
+
+    public function test_non_admin_group_manager_cannot_view_overview_page(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $tg = Group::factory()->create();
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $tg->id]);
+
+        $this->actingAs($manager)
+            ->get(route('groups.rules.overview'))
+            ->assertStatus(403);
+    }
+
+    public function test_overview_omits_rules_with_deleted_manager_group(): void
+    {
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id'  => $targetGroup->id,
+        ]);
+
+        \DB::table('groups')->where('id', $managerGroup->id)->delete();
+
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.rules.overview'))
+            ->assertStatus(200);
+    }
+}

--- a/tests/Feature/Groups/GroupManagerServiceTest.php
+++ b/tests/Feature/Groups/GroupManagerServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupAttributeDefinition;
+use App\Models\GroupAttributeValue;
+use App\Models\GroupManagerRuleByAttribute;
+use App\Models\GroupManagerRuleByGroup;
+use App\Models\GroupManagerRuleByTag;
+use App\Models\GroupTag;
+use App\Services\GroupManagerService;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class GroupManagerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private GroupManagerService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new GroupManagerService();
+    }
+
+    public function test_admin_user_is_detected(): void
+    {
+        $admin = User::factory()->create();
+        $adminGroup = Group::factory()->admin()->create();
+        $adminGroup->members()->attach($admin->id, ['created_at' => now()]);
+
+        $this->assertTrue($this->service->isAdmin($admin));
+    }
+
+    public function test_non_admin_user_is_not_detected_as_admin(): void
+    {
+        $user = User::factory()->create();
+        Group::factory()->create(); // non-admin group, user not a member
+        $this->assertFalse($this->service->isAdmin($user));
+    }
+
+    public function test_can_manage_via_specific_group_rule(): void
+    {
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id' => $targetGroup->id,
+        ]);
+
+        $this->assertTrue($this->service->canManage($manager, $targetGroup));
+    }
+
+    public function test_can_manage_via_tag_rule(): void
+    {
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+        GroupTag::create(['group_id' => $targetGroup->id, 'tag' => 'vacc']);
+        GroupManagerRuleByTag::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_tag' => 'vacc',
+        ]);
+
+        $this->assertTrue($this->service->canManage($manager, $targetGroup));
+    }
+
+    public function test_can_manage_via_attribute_rule(): void
+    {
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $def = GroupAttributeDefinition::factory()->create(['key' => 'region']);
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+        GroupAttributeValue::create([
+            'group_id' => $targetGroup->id,
+            'attribute_definition_id' => $def->id,
+            'value' => 'EUR',
+        ]);
+        GroupManagerRuleByAttribute::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_attribute_key' => 'region',
+            'target_attribute_value' => 'EUR',
+        ]);
+
+        $this->assertTrue($this->service->canManage($manager, $targetGroup));
+    }
+
+    public function test_cannot_manage_without_matching_rule(): void
+    {
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+        // no rules created
+
+        $this->assertFalse($this->service->canManage($manager, $targetGroup));
+    }
+
+    public function test_admin_can_manage_any_group(): void
+    {
+        $admin = User::factory()->create();
+        $adminGroup = Group::factory()->admin()->create();
+        $adminGroup->members()->attach($admin->id, ['created_at' => now()]);
+        $targetGroup = Group::factory()->create();
+
+        $this->assertTrue($this->service->canManage($admin, $targetGroup));
+    }
+
+    public function test_manageable_group_ids_are_cached(): void
+    {
+        Cache::flush();
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id' => $targetGroup->id,
+        ]);
+
+        $version = Cache::get('groups:cache_version', 0);
+        $this->service->manageableGroupIds($manager);
+        $this->assertTrue(Cache::has("user:{$manager->id}:manageable_groups:v{$version}"));
+    }
+
+    public function test_increment_cache_version_invalidates_results(): void
+    {
+        Cache::flush();
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+
+        $ids = $this->service->manageableGroupIds($manager);
+        $this->assertEmpty($ids);
+
+        GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id' => $targetGroup->id,
+        ]);
+        $this->service->incrementCacheVersion();
+
+        $ids = $this->service->manageableGroupIds($manager);
+        $this->assertContains($targetGroup->id, $ids);
+    }
+}

--- a/tests/Feature/Groups/GroupMemberTest.php
+++ b/tests/Feature/Groups/GroupMemberTest.php
@@ -1,0 +1,159 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupManagerRuleByGroup;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GroupMemberTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    private function adminUser(): User
+    {
+        $user = User::factory()->create();
+        Group::factory()->admin()->create()->members()->attach($user->id, ['created_at' => now()]);
+        return $user;
+    }
+
+    public function test_admin_can_view_members(): void
+    {
+        $group = Group::factory()->create();
+        $member = User::factory()->create(['first_name' => 'Alice']);
+        $group->members()->attach($member->id, ['created_at' => now()]);
+
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.members.index', $group))
+            ->assertStatus(200)
+            ->assertSee('Alice');
+    }
+
+    public function test_manager_can_view_managed_group_members(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $tg = Group::factory()->create();
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $tg->id]);
+
+        $this->actingAs($manager)->get(route('groups.members.index', $tg))->assertStatus(200);
+    }
+
+    public function test_manager_cannot_view_unmanaged_group_members(): void
+    {
+        $manager = User::factory()->create();
+        $mg = Group::factory()->create();
+        $managed = Group::factory()->create();
+        $unmanaged = Group::factory()->create();
+        $mg->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create(['manager_group_id' => $mg->id, 'target_group_id' => $managed->id]);
+
+        $this->actingAs($manager)->get(route('groups.members.index', $unmanaged))->assertStatus(403);
+    }
+
+    public function test_admin_can_add_member(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['id' => 1234567]);
+
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.members.store', $group), ['cid' => 1234567])
+            ->assertRedirect();
+
+        $this->assertTrue($group->members()->where('user_id', 1234567)->exists());
+    }
+
+    public function test_adding_already_existing_member_is_idempotent(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['id' => 1234567]);
+        $group->members()->attach(1234567, ['created_at' => now()]);
+
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.members.store', $group), ['cid' => 1234567])
+            ->assertRedirect()
+            ->assertSessionHas('info');
+
+        $this->assertEquals(1, $group->members()->where('user_id', 1234567)->count());
+    }
+
+    public function test_adding_unknown_cid_returns_404(): void
+    {
+        $group = Group::factory()->create();
+        $this->actingAs($this->adminUser())
+            ->post(route('groups.members.store', $group), ['cid' => 9999999])
+            ->assertStatus(404);
+    }
+
+    public function test_admin_can_remove_member(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['id' => 1234567]);
+        $group->members()->attach(1234567, ['created_at' => now()]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.members.destroy', [$group, $user]))
+            ->assertRedirect();
+
+        $this->assertFalse($group->members()->where('user_id', 1234567)->exists());
+    }
+
+    public function test_removing_non_member_is_idempotent(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['id' => 1234567]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.members.destroy', [$group, $user]))
+            ->assertRedirect()
+            ->assertSessionHas('info');
+    }
+
+    public function test_added_by_pivot_is_populated(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create(['id' => 1234567]);
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->post(route('groups.members.store', $group), ['cid' => 1234567]);
+
+        $pivot = $group->members()->where('user_id', 1234567)->first()->pivot;
+        $this->assertEquals($admin->id, $pivot->added_by);
+    }
+
+    public function test_cannot_remove_last_member_of_admin_group(): void
+    {
+        $adminGroup = Group::factory()->admin()->create();
+        $user = User::factory()->create();
+        $adminGroup->members()->attach($user->id, ['created_at' => now()]);
+
+        $this->actingAs($this->adminUser())
+            ->delete(route('groups.members.destroy', [$adminGroup, $user]))
+            ->assertSessionHasErrors('member');
+
+        $this->assertTrue($adminGroup->members()->where('user_id', $user->id)->exists());
+    }
+
+    public function test_member_search_by_name(): void
+    {
+        $group = Group::factory()->create();
+        $zara = User::factory()->create(['first_name' => 'Zara', 'last_name' => 'Smith', 'id' => 1111111]);
+        $bob = User::factory()->create(['first_name' => 'Bob', 'last_name' => 'Jones', 'id' => 2222222]);
+        $group->members()->attach($zara->id, ['created_at' => now()]);
+        $group->members()->attach($bob->id, ['created_at' => now()]);
+
+        $this->actingAs($this->adminUser())
+            ->get(route('groups.members.index', $group) . '?search=Zar')
+            ->assertSee('Zara')
+            ->assertDontSee('Bob');
+    }
+}

--- a/tests/Feature/Groups/GroupModelTest.php
+++ b/tests/Feature/Groups/GroupModelTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupTag;
+use App\Models\GroupAttributeDefinition;
+use App\Models\GroupAttributeValue;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GroupModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_group_has_uuid_primary_key(): void
+    {
+        $group = Group::factory()->create();
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $group->id
+        );
+    }
+
+    public function test_group_has_tags_relationship(): void
+    {
+        $group = Group::factory()->create();
+        GroupTag::create(['group_id' => $group->id, 'tag' => 'vacc']);
+        $this->assertCount(1, $group->fresh()->tags);
+        $this->assertEquals('vacc', $group->fresh()->tags->first()->tag);
+    }
+
+    public function test_group_has_attribute_values_relationship(): void
+    {
+        $def = GroupAttributeDefinition::factory()->create(['key' => 'region']);
+        $group = Group::factory()->create();
+        GroupAttributeValue::create([
+            'group_id' => $group->id,
+            'attribute_definition_id' => $def->id,
+            'value' => 'EUR',
+        ]);
+        $this->assertCount(1, $group->fresh()->attributeValues);
+    }
+
+    public function test_group_has_members_relationship(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create();
+        $group->members()->attach($user->id, ['created_at' => now()]);
+        $this->assertCount(1, $group->fresh()->members);
+    }
+
+    public function test_user_has_groups_relationship(): void
+    {
+        $group = Group::factory()->create();
+        $user = User::factory()->create();
+        $group->members()->attach($user->id, ['created_at' => now()]);
+        $this->assertCount(1, $user->fresh()->groups);
+    }
+}

--- a/tests/Feature/Groups/ManagesGroupsMiddlewareTest.php
+++ b/tests/Feature/Groups/ManagesGroupsMiddlewareTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace Tests\Feature\Groups;
+
+use App\Models\Group;
+use App\Models\GroupManagerRuleByGroup;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ManagesGroupsMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    public function test_unauthenticated_user_is_redirected(): void
+    {
+        $this->get('/groups')->assertRedirect('/login');
+    }
+
+    public function test_user_with_no_access_gets_403(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user)->get('/groups')->assertStatus(403);
+    }
+
+    public function test_admin_user_can_access_groups(): void
+    {
+        $user = User::factory()->create();
+        $adminGroup = Group::factory()->admin()->create();
+        $adminGroup->members()->attach($user->id, ['created_at' => now()]);
+
+        $this->actingAs($user)->get('/groups')->assertStatus(200);
+    }
+
+    public function test_group_manager_can_access_groups_index(): void
+    {
+        $manager = User::factory()->create();
+        $managerGroup = Group::factory()->create();
+        $targetGroup = Group::factory()->create();
+        $managerGroup->members()->attach($manager->id, ['created_at' => now()]);
+        GroupManagerRuleByGroup::create([
+            'manager_group_id' => $managerGroup->id,
+            'target_group_id' => $targetGroup->id,
+        ]);
+
+        $this->actingAs($manager)->get('/groups')->assertStatus(200);
+    }
+}


### PR DESCRIPTION
The motivation for the system is a foundation for https://github.com/thor/vcas-ok and its authorization management.

BEGIN_COMMIT_OVERRIDE
feat(groups): add attribute, tag, and direct group management system (#150)
- migrations: uniform FK style and explicit collation for string FK
- migrations: move FK declarations to bottom of migration 004
- models: add models, factories, and User relationship
- service: add GroupManagerService with caching
- middleware: add ManagesGroups middleware
- include UUID and slug in already-member output for add-admin command
- core: add attribute definition management
- add member management controller and view

feat(groups): add groups:add-admin artisan command  (#150)

feat(groups): add web interface for handling groups (#150)

test(groups): add tag/attribute rule deletion and scope-enforcement tests (#150)

feat(oauth): add groups OAuth scope and API response (#150)

docs(groups): add groups feature overview (#150)
END_COMMIT_OVERRIDE