### PR TITLE
ci: run tests and build multi-arch images in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,48 +1,186 @@
 ---
-name: "Build"
+name: "Test & Build"
 
 on:
   push:
     paths-ignore:
       - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
 
 env:
   IMAGE_NAME: vatsim-scandinavia/handover
-  TARGET_PLATFORMS: linux/amd64,linux/arm64
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  build-container:
-    name: Build Stands Container
+  test:
+    name: Test suite (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.3", "8.4"]
     steps:
-      - name: configure docker buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: login to github container registry
-        uses: docker/login-action@v2
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Validate composer
+        run: composer validate
+
+      - name: Copy environment file
+        run: cp -n .env.example .env || true
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ matrix.php-version }}-
+
+      - name: Install Composer dependencies
+        run: composer install --no-ansi --no-interaction --no-progress --prefer-dist
+
+      - name: Generate application key
+        run: php artisan key:generate
+
+      - name: Generate Passport keys
+        run: php artisan passport:keys --no-interaction
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Build front-end assets
+        run: |
+          npm ci
+          npm run build
+
+      - name: Execute unit and feature tests via PHPUnit
+        run: ./vendor/bin/phpunit --color=always --testdox
+
+  # Each platform is built on its own native runner in parallel and pushed by
+  # digest. This avoids the slow QEMU emulation of building linux/arm64 on an
+  # amd64 host. The digests are stitched into a single multi-arch manifest by
+  # the `merge` job below.
+  build-container:
+    name: Build image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Prepare platform slug
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Configure Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: setup container metadata
+      - name: Extract image labels
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+
+      - name: Build & push image by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:."
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # push-by-digest requires push=true, so only publish on non-PR events.
+          # On pull requests this still builds both arches natively as validation.
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-platform digests into one multi-arch manifest list and tag
+  # it. Gated on the test suite so a broken build never gets published.
+  merge:
+    name: Merge & publish multi-arch manifest
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - build-container
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Configure Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup container metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr
             type=sha,event=branch,prefix=
             type=semver,event=tag,pattern=v{{version}}
             type=semver,event=tag,pattern=v{{major}}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      - name: build & push container image
-        uses: docker/build-push-action@v4
-        with:
-          context: "{{defaultContext}}:."
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.TARGET_PLATFORMS }}
+      - name: Create manifest list & push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect published image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Rework the CI workflow so it actually exercises the test suite and builds container images efficiently.

- Add a PHPUnit test job on a PHP 8.3/8.4 matrix, building front-end assets with Vite so view-rendering feature tests pass.

- Build linux/amd64 and linux/arm64 on their own native runners in parallel (ubuntu-24.04 and ubuntu-24.04-arm), pushing by digest and merging into a single manifest list, instead of emulating arm64 via QEMU on a single amd64 runner.

- Validate builds on pull requests without publishing; only publish on push/tags, gated on the test job so a broken suite never ships an image.

- Add contents:read / packages:write permissions for the GHCR push.